### PR TITLE
fix: use X-Forwarded headers for login redirect behind reverse proxy

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -13,7 +13,16 @@ export async function proxy(request: NextRequest) {
   }
 
   // Invalid or no session - redirect to login
-  const loginUrl = new URL("/login", request.url);
+  // Use X-Forwarded headers when behind a reverse proxy
+  const forwardedHost = request.headers.get("x-forwarded-host");
+  const forwardedProto = request.headers.get("x-forwarded-proto") || "https";
+
+  let loginUrl: URL;
+  if (forwardedHost) {
+    loginUrl = new URL("/login", `${forwardedProto}://${forwardedHost}`);
+  } else {
+    loginUrl = new URL("/login", request.url);
+  }
 
   loginUrl.searchParams.set("callbackUrl", request.nextUrl.pathname);
 


### PR DESCRIPTION
When running behind a reverse proxy (like nginx), `request.url` contains the internal server URL (e.g., http://localhost:3000) instead of the public URL. This causes login redirects to go to the wrong host.

This fix reads X-Forwarded-Host and X-Forwarded-Proto headers to construct the correct public URL for redirects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)