### PR TITLE
feat: LDAP authentication support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,3 +41,18 @@ RECIPES_DISK_DIR=/app/uploads      # Defaults to /app/uploads
 # Option 4=Google OAuth (uncomment and remove OIDC above)
 # GOOGLE_CLIENT_ID=<google-client-id>
 # GOOGLE_CLIENT_SECRET=<google-client-secret>
+
+# Option 5=LDAP (Active Directory, OpenLDAP, FreeIPA, etc.)
+# When LDAP is enabled, signup is disabled - users must exist in LDAP directory.
+# LDAP_URL=ldap://localhost:389
+# LDAP_BASE_DN=ou=users,dc=example,dc=org
+# LDAP_BIND_DN=cn=readonly,dc=example,dc=org  # Optional, for authenticated bind
+# LDAP_BIND_PASSWORD=<bind-password>          # Optional
+# LDAP_USERNAME_ATTR=uid                      # Default: uid (use sAMAccountName for Active Directory)
+# LDAP_SEARCH_FILTER=(objectclass=posixAccount)  # Optional, filter to restrict which users can login
+
+# YunoHost LDAP example:
+# LDAP_URL=ldap://localhost:389
+# LDAP_BASE_DN=ou=users,dc=yunohost,dc=org
+# LDAP_USERNAME_ATTR=uid
+# LDAP_SEARCH_FILTER=(&(objectclass=posixAccount)(permission=cn=norish.main,ou=permission,dc=yunohost,dc=org))

--- a/README.md
+++ b/README.md
@@ -242,8 +242,23 @@ Configure **one** auth provider via environment variables to create your first a
 | **OIDC**     | `OIDC_NAME`, `OIDC_ISSUER`, `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET`, `OIDC_WELLKNOWN` (optional) | https://example.norish.com/api/auth/oauth2/callback/oidc |
 | **GitHub**   | `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`                                                      | https://example.norish.com/api/auth/callback/github      |
 | **Google**   | `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`                                                      | https://example.norish.com/api/auth/callback/google      |
+| **LDAP**     | `LDAP_URL`, `LDAP_BASE_DN`, `LDAP_BIND_DN` (optional), `LDAP_BIND_PASSWORD` (optional), `LDAP_USERNAME_ATTR`, `LDAP_SEARCH_FILTER` (optional) |  |
 
 After first login, manage all auth providers via **Settings => Admin**.
+
+### LDAP Authentication
+
+LDAP authentication allows users to sign in with their existing LDAP/Active Directory credentials. When LDAP is enabled, email/password signup is disabled - users must exist in the LDAP directory.
+
+| Variable              | Description                                      | Default |
+| --------------------- | ------------------------------------------------ | ------- |
+| `LDAP_URL`            | LDAP server URL                                  |         |
+| `LDAP_BASE_DN`        | Base DN for user search                          |         |
+| `LDAP_BIND_DN`        | Bind DN for authenticated search (optional)      |         |
+| `LDAP_BIND_PASSWORD`  | Bind password (optional)                         |         |
+| `LDAP_USERNAME_ATTR`  | Username attribute                               | `uid`   |
+| `LDAP_SEARCH_FILTER`  | Filter to restrict which users can login         |         |
+```
 
 ---
 

--- a/app/(auth)/login/components/ldap-form.tsx
+++ b/app/(auth)/login/components/ldap-form.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useState } from "react";
+import { Input, Button } from "@heroui/react";
+import { UserIcon, LockClosedIcon } from "@heroicons/react/24/outline";
+import { useRouter } from "next/navigation";
+
+interface LdapFormProps {
+  callbackUrl?: string;
+}
+
+export function LdapForm({ callbackUrl = "/" }: LdapFormProps) {
+  const router = useRouter();
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch("/api/auth/sign-in/ldap", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username,
+          password,
+        }),
+        credentials: "include",
+      });
+
+      const result = await response.json();
+
+      if (!response.ok || result.error) {
+        setError(result.error?.message || result.message || "Invalid username or password");
+      } else {
+        router.push(callbackUrl);
+      }
+    } catch {
+      setError("An error occurred. Please try again.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
+      <Input
+        isRequired
+        autoComplete="username"
+        label="Username"
+        placeholder="Your LDAP username"
+        startContent={<UserIcon className="text-default-400 h-4 w-4" />}
+        type="text"
+        value={username}
+        onValueChange={(value) => {
+          setUsername(value);
+          setError(null);
+        }}
+      />
+
+      <Input
+        isRequired
+        autoComplete="current-password"
+        label="Password"
+        placeholder="Enter your password"
+        startContent={<LockClosedIcon className="text-default-400 h-4 w-4" />}
+        type="password"
+        value={password}
+        onValueChange={(value) => {
+          setPassword(value);
+          setError(null);
+        }}
+      />
+
+      {error && <p className="text-small text-danger text-center">{error}</p>}
+
+      <Button
+        className="mt-2"
+        color="primary"
+        isDisabled={!username || !password}
+        isLoading={isLoading}
+        type="submit"
+      >
+        Sign in with LDAP
+      </Button>
+    </form>
+  );
+}

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,6 +1,6 @@
 import { LoginClient } from "./components/login-client";
 
-import { getAvailableProviders } from "@/server/auth/providers";
+import { getAvailableProviders, isLdapEnabled } from "@/server/auth/providers";
 import { isRegistrationEnabled } from "@/config/server-config-loader";
 
 export const dynamic = "force-dynamic";
@@ -11,18 +11,23 @@ interface LoginPageProps {
 }
 
 export default async function LoginPage({ searchParams }: LoginPageProps) {
-  const [providers, registrationEnabled] = await Promise.all([
+  const [providers, registrationEnabledConfig] = await Promise.all([
     getAvailableProviders(),
     isRegistrationEnabled(),
   ]);
 
+  // Disable registration if LDAP is enabled (users must use LDAP accounts)
+  const registrationEnabled = isLdapEnabled() ? false : registrationEnabledConfig;
+
   const { callbackUrl = "/", logout } = await searchParams;
   const justLoggedOut = logout === "true";
 
-  // Only auto-redirect for single OAuth provider
+  // Only auto-redirect for single OAuth provider (if no credential or LDAP providers)
   const oauthProviders = providers.filter((p) => p.type === "oauth");
   const hasCredential = providers.some((p) => p.type === "credential");
-  const shouldAutoRedirect = oauthProviders.length === 1 && !hasCredential && !justLoggedOut;
+  const hasLdap = providers.some((p) => p.type === "ldap");
+  const shouldAutoRedirect =
+    oauthProviders.length === 1 && !hasCredential && !hasLdap && !justLoggedOut;
 
   return (
     <LoginClient

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -2,7 +2,7 @@ import { redirect } from "next/navigation";
 
 import { SignupClient } from "./components/signup-client";
 
-import { isPasswordAuthEnabled } from "@/server/auth/providers";
+import { isPasswordAuthEnabled, isLdapEnabled } from "@/server/auth/providers";
 import { isRegistrationEnabled } from "@/config/server-config-loader";
 
 export const dynamic = "force-dynamic";
@@ -13,6 +13,11 @@ interface SignupPageProps {
 }
 
 export default async function SignupPage({ searchParams }: SignupPageProps) {
+  // Redirect to login if LDAP is enabled (users must use LDAP accounts)
+  if (isLdapEnabled()) {
+    redirect("/login");
+  }
+
   const [passwordEnabled, registrationEnabled] = await Promise.all([
     isPasswordAuthEnabled(),
     isRegistrationEnabled(),

--- a/config/env-config-server.ts
+++ b/config/env-config-server.ts
@@ -85,6 +85,14 @@ const ServerConfigSchema = z.object({
   GOOGLE_CLIENT_ID: z.string().optional(),
   GOOGLE_CLIENT_SECRET: z.string().optional(),
 
+  // LDAP Configuration
+  LDAP_URL: z.string().optional(), // e.g., ldap://localhost:389
+  LDAP_BIND_DN: z.string().optional(), // e.g., cn=admin,dc=example,dc=org
+  LDAP_BIND_PASSWORD: z.string().optional(),
+  LDAP_BASE_DN: z.string().optional(), // e.g., ou=users,dc=example,dc=org
+  LDAP_USERNAME_ATTR: z.string().default("uid"),
+  LDAP_SEARCH_FILTER: z.string().optional(), // e.g., (objectclass=posixAccount)
+
   // During build (SKIP_ENV_VALIDATION=1), use a placeholder key for Next.js compilation
   // At runtime, require a real 32+ char key - the placeholder is never persisted in the image
   MASTER_KEY: isBuild

--- a/docker/docker-compose.example.yml
+++ b/docker/docker-compose.example.yml
@@ -48,8 +48,18 @@ services:
       # Option 4: Google OAuth (uncomment and remove OIDC above)
       # GOOGLE_CLIENT_ID: <google-client-id>
       # GOOGLE_CLIENT_SECRET: <google-client-secret>
+
+      # Option 5: LDAP (Active Directory, OpenLDAP, FreeIPA, etc.)
+      # When LDAP is enabled, email/password signup is disabled - users must exist in LDAP directory.
+      # LDAP_URL: ldap://openldap:389
+      # LDAP_BASE_DN: ou=users,dc=example,dc=org
+      # LDAP_BIND_DN: cn=readonly,dc=example,dc=org  # Optional, for authenticated bind
+      # LDAP_BIND_PASSWORD: readonly                  # Optional
+      # LDAP_USERNAME_ATTR: uid                       # Default: uid (use sAMAccountName for Active Directory)
+      # LDAP_SEARCH_FILTER: (objectclass=inetOrgPerson)  # Optional, filter to restrict which users can login
     depends_on:
       - db
+      # - openldap  # Uncomment if using LDAP
 
   # PostgreSQL Database
   db:
@@ -80,7 +90,47 @@ services:
     ports:
       - "3003:3000"
 
+  # ─────────────────────────────────────────────────────────────────────────
+  # LDAP Server (for development/testing only)
+  # ─────────────────────────────────────────────────────────────────────────
+  # Uncomment to enable OpenLDAP for testing LDAP authentication
+  # Default credentials: admin / admin
+  # Test user: testuser / testpassword
+  #
+  # openldap:
+  #   image: osixia/openldap:1.5.0
+  #   container_name: openldap
+  #   restart: unless-stopped
+  #   environment:
+  #     LDAP_ORGANISATION: "Example Inc"
+  #     LDAP_DOMAIN: "example.org"
+  #     LDAP_ADMIN_PASSWORD: "admin"
+  #     LDAP_READONLY_USER: "true"
+  #     LDAP_READONLY_USER_USERNAME: "readonly"
+  #     LDAP_READONLY_USER_PASSWORD: "readonly"
+  #   ports:
+  #     - "389:389"
+  #     - "636:636"
+  #   volumes:
+  #     - ldap_data:/var/lib/ldap
+  #     - ldap_config:/etc/ldap/slapd.d
+  #
+  # # phpLDAPadmin - Web UI for managing LDAP (optional)
+  # phpldapadmin:
+  #   image: osixia/phpldapadmin:latest
+  #   container_name: phpldapadmin
+  #   restart: unless-stopped
+  #   environment:
+  #     PHPLDAPADMIN_LDAP_HOSTS: openldap
+  #     PHPLDAPADMIN_HTTPS: "false"
+  #   ports:
+  #     - "8080:80"
+  #   depends_on:
+  #     - openldap
+
 # Use this or map the volume to a host path if you want to persist data
 volumes:
   db_data:
   norish_data:
+  # ldap_data:    # Uncomment if using LDAP
+  # ldap_config:  # Uncomment if using LDAP

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "drizzle-zod": "0.8.3",
     "heic-convert": "^2.1.0",
     "html-entities": "^2.6.0",
+    "ldapts": "^8.0.20",
     "next": "16.0.7",
     "node-cron": "^4.2.1",
     "pg": "8.16.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       html-entities:
         specifier: ^2.6.0
         version: 2.6.0
+      ldapts:
+        specifier: ^8.0.20
+        version: 8.0.20
       next:
         specifier: 16.0.7
         version: 16.0.7(@babel/core@7.28.5)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -2491,6 +2494,9 @@ packages:
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
+  '@types/asn1@0.2.4':
+    resolution: {integrity: sha512-V91DSJ2l0h0gRhVP4oBfBzRBN9lAbPUkGDMCnwedqPKX2d84aAMc9CulOvxdw1f7DfEYx99afab+Rsm3e52jhA==}
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -2820,6 +2826,9 @@ packages:
   arraybuffer.prototype.slice@1.0.4:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
+
+  asn1@0.2.6:
+    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -4137,6 +4146,10 @@ packages:
     resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
     engines: {node: '>=0.10'}
 
+  ldapts@8.0.20:
+    resolution: {integrity: sha512-HdeQadccF1dmRYylD28p+sDgtGaVNlA6w/X96Y+gs06ew7qFkHX8MhPgLMNAIbI12GLeSJTFvtz3sxzXxJT2AQ==}
+    engines: {node: '>=20'}
+
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
@@ -4977,6 +4990,9 @@ packages:
 
   streamx@2.23.0:
     resolution: {integrity: sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==}
+
+  strict-event-emitter-types@2.0.0:
+    resolution: {integrity: sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -8258,6 +8274,10 @@ snapshots:
 
   '@types/aria-query@5.0.4': {}
 
+  '@types/asn1@0.2.4':
+    dependencies:
+      '@types/node': 24.10.1
+
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.28.5
@@ -8636,6 +8656,10 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
+
+  asn1@0.2.6:
+    dependencies:
+      safer-buffer: 2.1.2
 
   assertion-error@2.0.1: {}
 
@@ -10050,6 +10074,16 @@ snapshots:
     dependencies:
       language-subtag-registry: 0.3.23
 
+  ldapts@8.0.20:
+    dependencies:
+      '@types/asn1': 0.2.4
+      asn1: 0.2.6
+      debug: 4.4.3
+      strict-event-emitter-types: 2.0.0
+      whatwg-url: 15.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   levn@0.4.1:
     dependencies:
       prelude-ls: 1.2.1
@@ -10910,6 +10944,8 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
+
+  strict-event-emitter-types@2.0.0: {}
 
   string-width@4.2.3:
     dependencies:

--- a/server/auth/auth.ts
+++ b/server/auth/auth.ts
@@ -7,6 +7,8 @@ import { apiKey, genericOAuth } from "better-auth/plugins";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { APIError, createAuthMiddleware } from "better-auth/api";
 
+import { ldapPlugin, isLdapEnabled } from "./ldap-plugin";
+
 import {
   getCachedGitHubProvider,
   getCachedGoogleProvider,
@@ -303,6 +305,9 @@ function createAuth() {
       }),
 
       nextCookies(),
+
+      // LDAP authentication (conditionally enabled)
+      ...(isLdapEnabled() ? [ldapPlugin()] : []),
     ],
 
     hooks: {

--- a/server/auth/ldap-plugin.ts
+++ b/server/auth/ldap-plugin.ts
@@ -1,0 +1,147 @@
+import type { BetterAuthPlugin } from "better-auth";
+
+import { createAuthEndpoint, APIError } from "better-auth/api";
+import { Client } from "ldapts";
+import { z } from "zod";
+
+import { SERVER_CONFIG } from "@/config/env-config-server";
+import { authLogger } from "@/server/logger";
+
+// Check if LDAP is configured
+export function isLdapEnabled() {
+  return !!(SERVER_CONFIG.LDAP_URL && SERVER_CONFIG.LDAP_BASE_DN);
+}
+
+// Authenticate user against LDAP server
+async function authenticateLdap(username: string, password: string) {
+  const client = new Client({
+    url: SERVER_CONFIG.LDAP_URL!,
+    connectTimeout: 5000,
+  });
+
+  try {
+    // First, bind as admin (or anonymous) to search for the user
+    if (SERVER_CONFIG.LDAP_BIND_DN && SERVER_CONFIG.LDAP_BIND_PASSWORD) {
+      await client.bind(SERVER_CONFIG.LDAP_BIND_DN, SERVER_CONFIG.LDAP_BIND_PASSWORD);
+    }
+
+    // Build the search filter
+    const usernameAttr = SERVER_CONFIG.LDAP_USERNAME_ATTR;
+    let filter = `(${usernameAttr}=${username})`;
+
+    if (SERVER_CONFIG.LDAP_SEARCH_FILTER) {
+      // Combine with custom filter
+      filter = `(&${SERVER_CONFIG.LDAP_SEARCH_FILTER}(${usernameAttr}=${username}))`;
+    }
+
+    // Search for the user
+    const { searchEntries } = await client.search(SERVER_CONFIG.LDAP_BASE_DN!, {
+      filter,
+      scope: "sub",
+      attributes: ["dn", "mail", "email", "displayName", "cn", usernameAttr],
+    });
+
+    if (searchEntries.length === 0) {
+      throw new Error("User not found");
+    }
+
+    const userEntry = searchEntries[0];
+    const userDn = userEntry.dn;
+
+    // Unbind admin and rebind as user to verify password
+    await client.unbind();
+
+    const userClient = new Client({
+      url: SERVER_CONFIG.LDAP_URL!,
+      connectTimeout: 5000,
+    });
+
+    try {
+      await userClient.bind(userDn, password);
+      await userClient.unbind();
+    } catch {
+      throw new Error("Invalid password");
+    }
+
+    return userEntry;
+  } finally {
+    try {
+      await client.unbind();
+    } catch {
+      // Ignore unbind errors
+    }
+  }
+}
+
+const ldapInputSchema = z.object({
+  username: z.string().min(1),
+  password: z.string().min(1),
+});
+
+export function ldapPlugin(): BetterAuthPlugin {
+  return {
+    id: "ldap",
+    endpoints: {
+      signInLdap: createAuthEndpoint(
+        "/sign-in/ldap",
+        {
+          method: "POST",
+          body: ldapInputSchema,
+        },
+        async (ctx) => {
+          const { username, password } = ctx.body;
+
+          try {
+            const ldapResult = await authenticateLdap(username, password);
+
+            const usernameAttr = SERVER_CONFIG.LDAP_USERNAME_ATTR;
+            const email =
+              ldapResult.mail ||
+              ldapResult.email ||
+              `${ldapResult[usernameAttr] || username}@ldap.local`;
+            const name = ldapResult.displayName || ldapResult.cn || ldapResult[usernameAttr];
+
+            authLogger.info({ username }, "LDAP authentication successful");
+
+            // Find or create user
+            const existingUser = await ctx.context.internalAdapter.findUserByEmail(String(email));
+
+            let user;
+
+            if (existingUser) {
+              user = existingUser.user;
+            } else {
+              // Create new user
+              user = await ctx.context.internalAdapter.createUser({
+                email: String(email),
+                name: name ? String(name) : username,
+                emailVerified: true,
+              });
+            }
+
+            // Create session
+            const session = await ctx.context.internalAdapter.createSession(user.id);
+
+            // Set session cookie
+            await ctx.setSignedCookie(
+              ctx.context.authCookies.sessionToken.name,
+              session.token,
+              ctx.context.secret,
+              ctx.context.authCookies.sessionToken.options
+            );
+
+            return ctx.json({
+              user,
+              session,
+            });
+          } catch (error) {
+            authLogger.warn({ username, error }, "LDAP authentication failed");
+            throw new APIError("UNAUTHORIZED", {
+              message: "Invalid LDAP credentials",
+            });
+          }
+        }
+      ),
+    },
+  };
+}

--- a/types/dto/auth.ts
+++ b/types/dto/auth.ts
@@ -2,5 +2,5 @@ export interface ProviderInfo {
   id: string;
   name: string;
   icon: string;
-  type?: "oauth" | "credential";
+  type?: "oauth" | "credential" | "ldap";
 }


### PR DESCRIPTION
Add LDAP authentication as a new login method:
- Custom Better Auth plugin for LDAP authentication
- Support for search filters to restrict user access
- Auto-creation of local users on first LDAP login
- First LDAP user becomes server admin
- Disable email/password signup when LDAP is enabled

New environment variables:
- LDAP_URL: LDAP server URL
- LDAP_BASE_DN: Base DN for user search
- LDAP_BIND_DN: Optional bind DN for authenticated search
- LDAP_BIND_PASSWORD: Optional bind password
- LDAP_USERNAME_ATTR: Username attribute (default: uid)
- LDAP_SEARCH_FILTER: Optional filter to restrict users