### PR TITLE
Improved Parser Hinting for AI, Redirects, & URL normalization

### DIFF
--- a/server/parser/fetch.ts
+++ b/server/parser/fetch.ts
@@ -1,5 +1,23 @@
+import type { Page, BrowserContext } from "playwright-core";
+
 import { getBrowser } from "@/server/playwright";
 import { parserLogger as log } from "@/server/logger";
+import { getProviderForUrl, type PageProvider } from "@/server/parser/providers";
+
+/**
+ * Result from fetching a page via Playwright
+ * Includes the HTML content and optionally the page/context for later extraction
+ */
+export interface FetchResult {
+  /** Full HTML content from page.content() */
+  html: string;
+  /** Playwright Page object (kept open for provider extraction) */
+  page?: Page;
+  /** Matched provider for this URL (if any) */
+  provider?: PageProvider;
+  /** Browser context (must be closed by caller) */
+  context?: BrowserContext;
+}
 
 const BROWSER_HEADERS: Record<string, string> = {
   "User-Agent":
@@ -30,7 +48,37 @@ function getReferer(url: string): string {
   }
 }
 
-export async function fetchViaPlaywright(targetUrl: string): Promise<string> {
+/**
+ * Default wait strategy for recipe content
+ * Waits for any of: JSON-LD, microdata, or main content areas
+ */
+function defaultWaitStrategy(page: Page): Promise<void> {
+  return Promise.race([
+    page.locator('script[type="application/ld+json"]').first().waitFor({ timeout: 5000 }),
+    page.locator('[itemtype*="schema.org"]').first().waitFor({ timeout: 5000 }),
+    page
+      .locator('main, article, [role="main"], .content, #content')
+      .first()
+      .waitFor({ timeout: 5000 }),
+  ]);
+}
+
+/**
+ * Use provider-specific wait strategy if available
+ * Falls back to default strategy if provider doesn't implement getContentSelectors
+ */
+async function providerWaitForContent(page: Page, provider: PageProvider): Promise<void> {
+  if (provider.getContentSelectors) {
+    const { selectors, timeout = 5000 } = provider.getContentSelectors();
+
+    await Promise.race(selectors.map((s) => page.locator(s).first().waitFor({ timeout })));
+  } else {
+    // Fallback to default wait strategy if provider doesn't specify selectors
+    await defaultWaitStrategy(page);
+  }
+}
+
+export async function fetchViaPlaywright(targetUrl: string): Promise<FetchResult> {
   try {
     const browser = await getBrowser();
     const referer = getReferer(targetUrl);
@@ -73,32 +121,49 @@ export async function fetchViaPlaywright(targetUrl: string): Promise<string> {
       await page.waitForLoadState("networkidle").catch(() => {});
     }
 
+    // Get provider for this URL
+    const provider = getProviderForUrl(targetUrl);
+
+    if (provider) {
+      log.debug({ url: targetUrl, provider: provider.name }, "Matched provider for URL");
+    } else {
+      log.debug({ url: targetUrl }, "No specific provider matched, using default wait strategy");
+    }
+
+    // Wait for content to load using provider or default strategy
     try {
-      await Promise.race([
-        page.locator('script[type="application/ld+json"]').first().waitFor({ timeout: 5000 }),
-        page.locator('[itemtype*="schema.org"]').first().waitFor({ timeout: 5000 }),
-        page
-          .locator('main, article, [role="main"], .content, #content')
-          .first()
-          .waitFor({ timeout: 5000 }),
-      ]);
-    } catch {
+      if (provider) {
+        await providerWaitForContent(page, provider);
+        log.debug(
+          { url: targetUrl, provider: provider.name },
+          "Provider wait strategy completed successfully"
+        );
+      } else {
+        await defaultWaitStrategy(page);
+        log.debug({ url: targetUrl }, "Default wait strategy completed successfully");
+      }
+    } catch (error) {
       // Timeout is acceptable - proceed with whatever content we have
       log.debug(
-        { url: targetUrl },
-        "Recipe content selectors not found within timeout, proceeding anyway"
+        { url: targetUrl, err: error, provider: provider?.name },
+        "Wait strategy timed out, proceeding with current page content"
       );
     }
 
     const content = await page.content();
 
-    await context.close();
-
-    return content;
+    // Return page and context for potential later extraction
+    // IMPORTANT: Caller must close context when done
+    return {
+      html: content,
+      page,
+      provider: provider ?? undefined,
+      context,
+    };
   } catch (error) {
     log.warn({ err: error }, "Playwright fetch failed, Chrome may not be available");
 
-    return ""; // Fallback will use HTTP
+    return { html: "" }; // Fallback will use HTTP
   }
 }
 

--- a/server/parser/index.ts
+++ b/server/parser/index.ts
@@ -1,7 +1,9 @@
+import type { Page, BrowserContext } from "playwright-core";
+
 import { FullRecipeInsertDTO } from "@/types/dto/recipe";
 import { tryExtractRecipeFromJsonLd } from "@/server/parser/jsonld";
 import { tryExtractRecipeFromMicrodata } from "@/server/parser/microdata";
-import { fetchViaPuppeteer } from "@/server/parser/fetch";
+import { fetchViaPuppeteer, type FetchResult } from "@/server/parser/fetch";
 import { extractRecipeWithAI } from "@/server/ai/recipe-parser";
 import {
   getContentIndicators,
@@ -11,6 +13,8 @@ import {
 } from "@/config/server-config-loader";
 import { isVideoUrl } from "@/server/helpers";
 import { parserLogger as log } from "@/server/logger";
+import { type ContentSelectors } from "@/server/parser/providers/base";
+import { getProviderForUrl } from "@/server/parser/providers";
 
 export interface ParseRecipeResult {
   recipe: FullRecipeInsertDTO;
@@ -21,10 +25,42 @@ export interface ParseRecipeResult {
 export async function parseRecipeFromUrl(
   url: string,
   allergies?: string[],
-  forceAI?: boolean
+  forceAI?: boolean,
+  _redirectDepth: number = 0
 ): Promise<ParseRecipeResult> {
+  // Protect against infinite redirect loops
+  const MAX_REDIRECT_DEPTH = 3;
+
+  if (_redirectDepth > MAX_REDIRECT_DEPTH) {
+    throw new Error(
+      `Maximum redirect depth (${MAX_REDIRECT_DEPTH}) exceeded. Possible redirect loop detected.`
+    );
+  }
+
+  // Normalize URL first (remove tracking params, etc.)
+  let normalizedUrl = url;
+  const provider = getProviderForUrl(url);
+
+  if (provider) {
+    log.debug({ url, provider: provider.name }, "Provider matched for URL");
+
+    if (provider.normalizeUrl) {
+      const normalized = provider.normalizeUrl(url);
+
+      if (normalized) {
+        normalizedUrl = normalized.url;
+        log.info(
+          { original: url, normalized: normalizedUrl, provider: provider.name },
+          "URL normalized by provider"
+        );
+      }
+    }
+  } else {
+    log.debug({ url }, "No provider matched for URL");
+  }
+
   // Check if URL is a video platform (YouTube, Instagram, TikTok, etc.)
-  if (await isVideoUrl(url)) {
+  if (await isVideoUrl(normalizedUrl)) {
     const videoEnabled = await isVideoParsingEnabled();
 
     if (!videoEnabled) {
@@ -33,7 +69,7 @@ export async function parseRecipeFromUrl(
 
     try {
       const { processVideoRecipe } = await import("@/server/video/processor");
-      const recipe = await processVideoRecipe(url, allergies);
+      const recipe = await processVideoRecipe(normalizedUrl, allergies);
 
       return { recipe, usedAI: true };
     } catch (error: any) {
@@ -42,77 +78,152 @@ export async function parseRecipeFromUrl(
     }
   }
 
-  const html = await fetchViaPuppeteer(url);
+  // Fetch full HTML and keep page/provider reference for potential later extraction
+  const fetchResult = await fetchViaPuppeteer(normalizedUrl);
 
-  if (!html) throw new Error("Cannot fetch recipe page.");
+  // Ensure browser resources are ALWAYS cleaned up, even on errors
+  try {
+    const html = fetchResult.html;
 
-  const isRecipe = await isPageLikelyRecipe(html);
+    if (!html) {
+      throw new Error("Cannot fetch recipe page.");
+    }
 
-  if (!isRecipe) {
-    throw new Error("Page does not appear to contain a recipe.");
-  }
+    // Check if provider detects a redirect (e.g., Pinterest bookmark to external site)
+    if (fetchResult.page && fetchResult.provider?.detectRedirect) {
+      try {
+        const redirectResult = await fetchResult.provider.detectRedirect(
+          fetchResult.page,
+          normalizedUrl
+        );
 
-  // Check if AI-only mode is requested or globally enabled
-  const useAIOnly = forceAI ?? (await shouldAlwaysUseAI());
+        if (redirectResult) {
+          log.info(
+            {
+              originalUrl: normalizedUrl,
+              redirectUrl: redirectResult.redirectUrl,
+              redirectDepth: _redirectDepth,
+            },
+            "Provider detected redirect, re-parsing target URL"
+          );
 
-  if (useAIOnly) {
-    log.info({ url }, "AI-only mode enabled, skipping structured parsers");
+          // Clean up current page before redirecting
+          await safeCloseContext(fetchResult.context);
+
+          // Recursively parse the redirect target with depth tracking
+          return parseRecipeFromUrl(
+            redirectResult.redirectUrl,
+            allergies,
+            forceAI,
+            _redirectDepth + 1
+          );
+        }
+      } catch (error) {
+        log.warn(
+          { err: error, url: normalizedUrl },
+          "Redirect detection failed, continuing with current page"
+        );
+      }
+    }
+
+    const isRecipe = await isPageLikelyRecipe(html);
+
+    if (!isRecipe) {
+      throw new Error("Page does not appear to contain a recipe.");
+    }
+
+    // Check if AI-only mode is requested or globally enabled
+    const useAIOnly = forceAI ?? (await shouldAlwaysUseAI());
+
+    if (useAIOnly) {
+      log.info({ url }, "AI-only mode enabled, skipping structured parsers");
+      const aiEnabled = await isAIEnabled();
+
+      if (!aiEnabled) {
+        throw new Error("AI-only import requested but AI is not enabled.");
+      }
+
+      // Get focused content from provider if available
+      const focusedHtml = await extractFocusedContent(fetchResult);
+      const contentForAI = focusedHtml || html;
+
+      const aiResult = await extractRecipeWithAI(contentForAI, url, allergies);
+
+      if (aiResult.success) {
+        return { recipe: aiResult.data, usedAI: true };
+      }
+
+      throw new Error(`AI extraction failed: ${aiResult.error}`);
+    }
+
+    // Standard parsing flow: ALWAYS try structured parsers first on FULL HTML
+    const jsonLdParsed = await tryExtractRecipeFromJsonLd(url, html);
+    const containsStepsAndIngredients =
+      !!jsonLdParsed &&
+      Array.isArray(jsonLdParsed.recipeIngredients) &&
+      jsonLdParsed.recipeIngredients.length > 0 &&
+      Array.isArray(jsonLdParsed.steps) &&
+      jsonLdParsed.steps.length > 0;
+
+    if (containsStepsAndIngredients) {
+      return { recipe: jsonLdParsed, usedAI: false };
+    }
+
+    const microParsed = await tryExtractRecipeFromMicrodata(url, html);
+    const containsMicroStepsAndIngredients =
+      !!microParsed &&
+      Array.isArray(microParsed.recipeIngredients) &&
+      microParsed.recipeIngredients.length > 0 &&
+      Array.isArray(microParsed.steps) &&
+      microParsed.steps.length > 0;
+
+    if (containsMicroStepsAndIngredients) {
+      return { recipe: microParsed, usedAI: false };
+    }
+
+    // Only attempt AI extraction if AI is enabled
     const aiEnabled = await isAIEnabled();
 
-    if (!aiEnabled) {
-      throw new Error("AI-only import requested but AI is not enabled.");
+    if (aiEnabled) {
+      log.info({ url }, "Falling back to AI extraction");
+
+      // Get focused content from provider if available
+      const focusedHtml = await extractFocusedContent(fetchResult);
+      const contentForAI = focusedHtml || html;
+
+      const aiResult = await extractRecipeWithAI(contentForAI, url, allergies);
+
+      if (aiResult.success) {
+        return { recipe: aiResult.data, usedAI: true };
+      }
+
+      log.warn(
+        { url, error: aiResult.error, code: aiResult.code },
+        "AI fallback extraction failed"
+      );
     }
 
-    const aiResult = await extractRecipeWithAI(html, url, allergies);
-
-    if (aiResult.success) {
-      return { recipe: aiResult.data, usedAI: true };
-    }
-
-    throw new Error(`AI extraction failed: ${aiResult.error}`);
+    log.error({ url }, "All extraction methods failed");
+    throw new Error("Cannot parse recipe.");
+  } finally {
+    // ALWAYS clean up browser resources, even if an error occurred
+    await safeCloseContext(fetchResult.context);
   }
+}
 
-  // Standard parsing flow: try structured parsers first, then AI fallback
-  const jsonLdParsed = await tryExtractRecipeFromJsonLd(url, html);
-  const containsStepsAndIngredients =
-    !!jsonLdParsed &&
-    Array.isArray(jsonLdParsed.recipeIngredients) &&
-    jsonLdParsed.recipeIngredients.length > 0 &&
-    Array.isArray(jsonLdParsed.steps) &&
-    jsonLdParsed.steps.length > 0;
+/**
+ * Safely close a browser context with error handling
+ * Prevents cleanup errors from shadowing actual errors
+ */
+async function safeCloseContext(context: BrowserContext | undefined): Promise<void> {
+  if (!context) return;
 
-  if (containsStepsAndIngredients) {
-    return { recipe: jsonLdParsed, usedAI: false };
+  try {
+    await context.close();
+  } catch (error) {
+    // Log but don't throw - cleanup errors shouldn't shadow real errors
+    log.warn({ err: error }, "Failed to close browser context during cleanup");
   }
-
-  const microParsed = await tryExtractRecipeFromMicrodata(url, html);
-  const containsMicroStepsAndIngredients =
-    !!microParsed &&
-    Array.isArray(microParsed.recipeIngredients) &&
-    microParsed.recipeIngredients.length > 0 &&
-    Array.isArray(microParsed.steps) &&
-    microParsed.steps.length > 0;
-
-  if (containsMicroStepsAndIngredients) {
-    return { recipe: microParsed, usedAI: false };
-  }
-
-  // Only attempt AI extraction if AI is enabled
-  const aiEnabled = await isAIEnabled();
-
-  if (aiEnabled) {
-    log.info({ url }, "Falling back to AI extraction");
-    const aiResult = await extractRecipeWithAI(html, url, allergies);
-
-    if (aiResult.success) {
-      return { recipe: aiResult.data, usedAI: true };
-    }
-
-    log.warn({ url, error: aiResult.error, code: aiResult.code }, "AI fallback extraction failed");
-  }
-
-  log.error({ url }, "All extraction methods failed");
-  throw new Error("Cannot parse recipe.");
 }
 
 export async function isPageLikelyRecipe(html: string): Promise<boolean> {
@@ -125,4 +236,94 @@ export async function isPageLikelyRecipe(html: string): Promise<boolean> {
     indicators.contentIndicators.filter((i) => lowered.includes(i.toLowerCase())).length >= 2;
 
   return hasSchema || hasContentHints;
+}
+
+/**
+ * Helper function to extract focused content using provider
+ * Only called before AI extraction to reduce token costs
+ */
+async function extractFocusedContent(fetchResult: FetchResult): Promise<string | null> {
+  const { page, provider } = fetchResult;
+
+  if (!page || !provider) {
+    log.debug("No page or provider available for focused content extraction");
+
+    return null;
+  }
+
+  log.debug({ provider: provider.name }, "Attempting focused content extraction with provider");
+
+  try {
+    // Try custom extraction function first
+    if (provider.extractContent) {
+      const extracted = await provider.extractContent(page);
+
+      if (extracted) {
+        log.info(
+          { provider: provider.name, contentLength: extracted.length },
+          "Provider successfully extracted focused content via custom extraction"
+        );
+
+        return extracted;
+      } else {
+        log.debug({ provider: provider.name }, "Provider custom extraction returned null");
+      }
+    }
+
+    // Try config-based extraction
+    if (provider.getContentSelectors) {
+      const extracted = await extractWithSelectors(page, provider.getContentSelectors());
+
+      if (extracted) {
+        log.info(
+          { provider: provider.name, contentLength: extracted.length },
+          "Provider successfully extracted focused content via selectors"
+        );
+
+        return extracted;
+      } else {
+        log.debug({ provider: provider.name }, "Provider selector-based extraction returned null");
+      }
+    }
+
+    log.debug(
+      { provider: provider.name },
+      "Provider has no extraction methods, falling back to full page content"
+    );
+  } catch (error) {
+    log.warn(
+      { err: error, provider: provider.name },
+      "Provider content extraction failed, falling back to full page content"
+    );
+  }
+
+  return null;
+}
+
+/**
+ * Generic selector-based extraction
+ * Tries selectors in priority order and returns HTML from first match
+ */
+async function extractWithSelectors(page: Page, config: ContentSelectors): Promise<string | null> {
+  const { selectors, timeout = 5000 } = config;
+
+  for (const selector of selectors) {
+    try {
+      const element = page.locator(selector).first();
+
+      await element.waitFor({ timeout });
+
+      // Extract HTML (preserves structure for potential fallback to structured parsing)
+      const html = await element.innerHTML();
+
+      log.debug({ selector }, "Extracted focused content using selector");
+
+      return html;
+    } catch {
+      // Element not found or timeout, try next selector
+      continue;
+    }
+  }
+
+  return null;
 }

--- a/server/parser/providers/base.ts
+++ b/server/parser/providers/base.ts
@@ -1,0 +1,98 @@
+import type { Page } from "playwright-core";
+
+/**
+ * Configuration for content selectors
+ * Used for both waiting for content and extracting focused content
+ */
+export interface ContentSelectors {
+  /** Priority-ordered selectors to try */
+  selectors: string[];
+  /** Timeout in milliseconds for each selector (default: 5000) */
+  timeout?: number;
+}
+
+/**
+ * Result from URL normalization
+ */
+export interface NormalizeUrlResult {
+  /** The normalized URL (with tracking params removed, etc.) */
+  url: string;
+  /** If true, indicates the URL should be re-fetched with the normalized version */
+  shouldRefetch?: boolean;
+}
+
+/**
+ * Result from redirect detection
+ */
+export interface RedirectDetectionResult {
+  /** The detected redirect target URL */
+  redirectUrl: string;
+  /** Reason for the redirect (for error messages) */
+  reason?: string;
+}
+
+/**
+ * Interface for website-specific page providers
+ * Providers can customize wait strategies and content extraction for specific websites
+ */
+export interface PageProvider {
+  readonly name: string;
+
+  /**
+   * Check if this provider handles the given URL
+   * Provider is responsible for its own URL/hostname matching logic
+   */
+  matches(url: string): boolean;
+
+  /**
+   * Normalize/clean the URL before fetching
+   * Use this to remove tracking parameters, convert mobile URLs, etc.
+   * @param url - The original URL
+   * @returns Normalized URL result, or null if no normalization needed
+   */
+  normalizeUrl?(url: string): NormalizeUrlResult | null;
+
+  /**
+   * Detect if the page redirects to another recipe URL
+   * Use this for aggregator sites or social media bookmarks that link elsewhere
+   * @param page - Playwright page object
+   * @param url - The URL being fetched
+   * @returns Redirect detection result, or null if no redirect detected
+   */
+  detectRedirect?(page: Page, url: string): Promise<RedirectDetectionResult | null>;
+
+  /**
+   * Config-based approach: Return selectors for waiting and extraction
+   * These selectors will be used both for waiting during fetch and extracting focused content for AI
+   * @returns ContentSelectors configuration, or undefined if using custom extraction
+   */
+  getContentSelectors?(): ContentSelectors;
+
+  /**
+   * Custom extraction function for complex cases
+   * Use this when simple selectors aren't enough (e.g., "Jump to Recipe" button detection)
+   * @param page - Playwright page object
+   * @returns HTML string of extracted content, or null to use full page content
+   */
+  extractContent?(page: Page): Promise<string | null>;
+}
+
+/**
+ * Base provider with simple hostname matching
+ */
+export abstract class BasePageProvider implements PageProvider {
+  abstract readonly name: string;
+  protected abstract readonly hostnames: string[];
+
+  matches(url: string): boolean {
+    try {
+      const hostname = new URL(url).hostname.toLowerCase();
+
+      return this.hostnames.some(
+        (h) => hostname === h.toLowerCase() || hostname.endsWith("." + h.toLowerCase())
+      );
+    } catch {
+      return false;
+    }
+  }
+}

--- a/server/parser/providers/generic-recipe.ts
+++ b/server/parser/providers/generic-recipe.ts
@@ -1,0 +1,103 @@
+import type { Page } from "playwright-core";
+
+import { BasePageProvider } from "./base";
+
+import { parserLogger as log } from "@/server/logger";
+
+/**
+ * Generic Recipe Provider
+ * Implements common recipe site patterns like "Jump to Recipe" buttons
+ * Acts as a universal fallback for ALL recipe sites, not just specific domains
+ */
+export class GenericRecipeProvider extends BasePageProvider {
+  readonly name = "generic-recipe";
+  protected readonly hostnames: string[] = []; // Override matches() instead
+
+  /**
+   * Match ALL URLs as a fallback provider
+   * This provider uses common recipe patterns that work across many sites
+   * It should be registered LAST in the provider list so specific providers take precedence
+   */
+  matches(_url: string): boolean {
+    // Always return true - this is a catch-all provider
+    // Should be registered last in provider list so specific providers match first
+    return true;
+  }
+
+  async extractContent(page: Page): Promise<string | null> {
+    log.debug("GenericRecipeProvider: attempting to extract focused content");
+
+    // Strategy 1: Look for "Jump to Recipe" or "Skip to Recipe" button
+    const jumpButtonSelectors = [
+      'a:has-text("Jump to Recipe")',
+      'a:has-text("Skip to Recipe")',
+      'a:has-text("Jump to recipe")',
+      'a:has-text("Skip to recipe")',
+      'button:has-text("Jump to Recipe")',
+      'button:has-text("Skip to Recipe")',
+      '[class*="jump"]:has-text("Recipe")',
+      '[class*="skip"]:has-text("Recipe")',
+    ];
+
+    for (const selector of jumpButtonSelectors) {
+      try {
+        const jumpButton = page.locator(selector).first();
+
+        if ((await jumpButton.count()) > 0) {
+          // Try to get the href target
+          const href = await jumpButton.getAttribute("href");
+
+          if (href?.startsWith("#")) {
+            const targetId = href.slice(1);
+            const target = page.locator(`#${targetId}`);
+
+            if ((await target.count()) > 0) {
+              const html = await target.innerHTML();
+
+              log.debug({ targetId }, "Found content via Jump to Recipe button");
+
+              return html;
+            }
+          }
+        }
+      } catch {
+        // Button not found or navigation failed, try next selector
+        continue;
+      }
+    }
+
+    // Strategy 2: Look for common recipe container patterns
+    const containerSelectors = [
+      ".recipe-card",
+      ".recipe-content",
+      '[class*="recipe-container"]',
+      '[class*="recipeContainer"]',
+      'article[class*="recipe"]',
+      '[itemtype*="schema.org/Recipe"]', // Microdata hint
+      ".wprm-recipe-container", // WP Recipe Maker plugin
+      ".tasty-recipes", // Tasty Recipes plugin
+      ".easyrecipe", // Easy Recipe plugin
+    ];
+
+    for (const selector of containerSelectors) {
+      try {
+        const element = page.locator(selector).first();
+
+        if ((await element.count()) > 0) {
+          const html = await element.innerHTML();
+
+          log.debug({ selector }, "Found content via container pattern");
+
+          return html;
+        }
+      } catch {
+        // Element not found, try next selector
+        continue;
+      }
+    }
+
+    log.debug("GenericRecipeProvider: no generic patterns matched");
+
+    return null; // No generic pattern found, use full page
+  }
+}

--- a/server/parser/providers/index.ts
+++ b/server/parser/providers/index.ts
@@ -1,0 +1,48 @@
+import { PageProvider } from "./base";
+import { PinterestProvider } from "./pinterest";
+import { GenericRecipeProvider } from "./generic-recipe";
+
+/**
+ * Registry of all available page providers
+ * IMPORTANT: Providers are checked in order - specific providers MUST come before generic ones
+ *
+ * Order matters:
+ * 1. Site-specific providers first (Pinterest, etc.)
+ * 2. GenericRecipeProvider MUST be last - it matches ALL URLs as a fallback
+ */
+const PROVIDERS: PageProvider[] = [
+  // Specific providers first (higher priority)
+  new PinterestProvider(),
+
+  // Future site-specific providers should go here:
+  // new AllRecipesProvider(),
+  // new FoodNetworkProvider(),
+
+  // MUST be last: GenericRecipeProvider matches ALL URLs as a universal fallback
+  new GenericRecipeProvider(),
+];
+
+/**
+ * Find a provider that can handle the given URL
+ * @param url - The recipe URL to match
+ * @returns The first matching provider, or null if none found
+ */
+export function getProviderForUrl(url: string): PageProvider | null {
+  for (const provider of PROVIDERS) {
+    if (provider.matches(url)) {
+      return provider;
+    }
+  }
+
+  return null;
+}
+
+// Export types for testing and extension
+export type {
+  PageProvider,
+  ContentSelectors,
+  NormalizeUrlResult,
+  RedirectDetectionResult,
+} from "./base";
+export { PinterestProvider } from "./pinterest";
+export { GenericRecipeProvider } from "./generic-recipe";

--- a/server/parser/providers/pinterest.ts
+++ b/server/parser/providers/pinterest.ts
@@ -1,0 +1,110 @@
+import type { Page } from "playwright-core";
+
+import {
+  BasePageProvider,
+  type ContentSelectors,
+  type NormalizeUrlResult,
+  type RedirectDetectionResult,
+} from "./base";
+
+import { parserLogger as log } from "@/server/logger";
+
+/**
+ * Pinterest Provider
+ * Handles URL normalization, redirect detection, and focused extraction for Pinterest
+ */
+export class PinterestProvider extends BasePageProvider {
+  readonly name = "pinterest";
+  protected readonly hostnames = ["pinterest.com"];
+
+  /**
+   * Normalize Pinterest URLs by removing tracking parameters
+   * Example: /pin/123/sent/?invite_code=abc → /pin/123/
+   */
+  normalizeUrl(url: string): NormalizeUrlResult | null {
+    try {
+      const parsed = new URL(url);
+
+      // Remove common Pinterest tracking parameters
+      const trackingParams = ["invite_code", "sender", "sfo", "invite_sent", "share"];
+
+      trackingParams.forEach((param) => parsed.searchParams.delete(param));
+
+      // Remove /sent/ path component
+      let pathname = parsed.pathname;
+
+      if (pathname.includes("/sent/")) {
+        pathname = pathname.replace("/sent/", "/");
+      }
+
+      // Ensure trailing slash for pin URLs
+      if (pathname.match(/^\/pin\/\d+$/) && !pathname.endsWith("/")) {
+        pathname += "/";
+      }
+
+      parsed.pathname = pathname;
+
+      const normalizedUrl = parsed.toString();
+
+      // Only return if something changed
+      if (normalizedUrl !== url) {
+        log.debug({ original: url, normalized: normalizedUrl }, "Normalized Pinterest URL");
+
+        return { url: normalizedUrl };
+      }
+
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Detect if Pinterest pin redirects to an external recipe
+   * Pinterest includes the original URL in og:see_also meta tag for external links
+   */
+  async detectRedirect(page: Page, url: string): Promise<RedirectDetectionResult | null> {
+    try {
+      // Pinterest stores the original external URL in og:see_also meta tag
+      // Example: <meta content="https://example.com/recipe" property="og:see_also"/>
+      const metaTag = page.locator('meta[property="og:see_also"], meta[name="og:see_also"]');
+
+      if ((await metaTag.count()) > 0) {
+        const content = await metaTag.first().getAttribute("content");
+
+        if (content && !content.includes("pinterest.com")) {
+          // This is an external link - Pinterest is just a bookmark
+          log.info(
+            { pinterestUrl: url, targetUrl: content },
+            "Detected Pinterest redirect to external recipe via og:see_also"
+          );
+
+          return {
+            redirectUrl: content,
+            reason: "Pinterest pin links to external recipe",
+          };
+        }
+      }
+
+      return null;
+    } catch (error) {
+      log.warn({ err: error, url }, "Error detecting Pinterest redirect");
+
+      return null;
+    }
+  }
+
+  getContentSelectors(): ContentSelectors {
+    return {
+      selectors: [
+        // Pinterest recipe container (most specific)
+        '[data-test-id="pin-recipe-container"]',
+        // Recipe ingredient markers
+        '[data-test-id="recipe-ingredient"]',
+        // Recipe-related divs (Pinterest often uses generic divs)
+        'div[role="article"]',
+      ],
+      timeout: 5000,
+    };
+  }
+}

--- a/server/video/instagram.ts
+++ b/server/video/instagram.ts
@@ -108,10 +108,15 @@ export async function processInstagramImagePost(
   if (description.length < 50) {
     log.info({ url }, "Description from yt-dlp too short, attempting Playwright scrape");
     try {
-      const html = await fetchViaPlaywright(url);
+      const fetchResult = await fetchViaPlaywright(url);
 
-      if (html) {
-        description = extractInstagramCaption(html);
+      // Clean up browser resources
+      if (fetchResult.context) {
+        await fetchResult.context.close();
+      }
+
+      if (fetchResult.html) {
+        description = extractInstagramCaption(fetchResult.html);
         log.info(
           { url, descriptionLength: description.length },
           "Extracted caption via Playwright"


### PR DESCRIPTION
- Adds Parser Provider system to allow domains to define how the parser functions
- Providers can normalize the URL to remove tracking/share URL patterns from social media websites. This helps prevent two recipes from being added by simply having different tracking URLs.
- Providers can change the URL being imported. For example, a [Pinterest bookmark](https://www.pinterest.com/pin/484066659972685570) will now resolve to the [recipe](https://pinchmegood.com/easy-10-minute-healthy-tzatziki-sauce/).
- Default Provider adds detection for recipe websites that use "Jump to Recipe" hints at where we can find the DOM to send to the AI context.

I tried to make sure this doesn't prevent metadata/json parsing, but moreover improves how the AI is fed data. Since this is my first PR I'm very open to changes. This tool has been great to use for my family! :D