### PR TITLE
fix: encoding html entities on json import

### DIFF
--- a/__tests__/ai/features/recipe-extraction/normalizer.test.ts
+++ b/__tests__/ai/features/recipe-extraction/normalizer.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, vi } from "vitest";
 import {
   validateExtractionOutput,
   getExtractionLogContext,
+  normalizeExtractionOutput,
 } from "@/server/ai/features/recipe-extraction/normalizer";
 
 // Mock the normalizeExtractionOutput dependencies for isolation
@@ -263,3 +264,251 @@ function createPartialOutput(overrides: Partial<RecipeExtractionOutput>): Recipe
     ...overrides,
   } as RecipeExtractionOutput;
 }
+
+describe("normalizeExtractionOutput - HTML Entity Decoding", () => {
+  it("decodes HTML entities in US ingredients and keeps comments", async () => {
+    const output: RecipeExtractionOutput = {
+      "@context": "https://schema.org",
+      "@type": "Recipe",
+      name: "Test Recipe",
+      description: "Test",
+      recipeIngredient: {
+        metric: ["100g flour"],
+        us: ["1 cup flour &#8211; all-purpose", "2 eggs &#8211; beaten"],
+      },
+      recipeInstructions: {
+        metric: ["Mix well"],
+        us: ["Mix well"],
+      },
+      recipeYield: "4",
+      cookTime: null,
+      prepTime: null,
+      totalTime: null,
+      keywords: [],
+      nutrition: { calories: 0, fat: 0, carbs: 0, protein: 0 },
+    };
+
+    // Mock normalizeRecipeFromJson to return metric version
+    const { normalizeRecipeFromJson } = await import("@/server/parser/normalize");
+
+    vi.mocked(normalizeRecipeFromJson).mockResolvedValue({
+      name: "Test Recipe",
+      description: "Test",
+      url: null,
+      image: undefined,
+      servings: undefined,
+      prepMinutes: undefined,
+      cookMinutes: undefined,
+      totalMinutes: undefined,
+      calories: null,
+      fat: null,
+      carbs: null,
+      protein: null,
+      recipeIngredients: [
+        {
+          ingredientId: null,
+          ingredientName: "flour",
+          amount: 100,
+          unit: "g",
+          systemUsed: "metric",
+          order: 0,
+        },
+      ],
+      steps: [{ step: "Mix well", order: 1, systemUsed: "metric", images: [] }],
+      systemUsed: "metric",
+      tags: [],
+      images: [],
+    } as any);
+
+    const result = await normalizeExtractionOutput(output);
+
+    expect(result).toBeTruthy();
+    // Check US ingredients were decoded (with &#8211;)
+    const usIngredients = result?.recipeIngredients?.filter((ing) => ing.systemUsed === "us");
+
+    expect(usIngredients).toHaveLength(2);
+    expect(usIngredients?.[0].ingredientName).toContain("–"); // en dash
+    expect(usIngredients?.[0].ingredientName).toContain("all-purpose"); // comment preserved
+    expect(usIngredients?.[0].ingredientName).not.toContain("&#8211;");
+    expect(usIngredients?.[1].ingredientName).toContain("–");
+    expect(usIngredients?.[1].ingredientName).toContain("beaten");
+  });
+
+  it("decodes HTML entities in US steps and keeps full text", async () => {
+    const output: RecipeExtractionOutput = {
+      "@context": "https://schema.org",
+      "@type": "Recipe",
+      name: "Test Recipe",
+      description: "Test",
+      recipeIngredient: {
+        metric: ["100g flour"],
+        us: ["1 cup flour"],
+      },
+      recipeInstructions: {
+        metric: ["Mix well"],
+        us: [
+          "Bake at 350&#176;F &#8211; use convection",
+          "Cool for 10 minutes &#8211; don&#39;t rush",
+        ],
+      },
+      recipeYield: "4",
+      cookTime: null,
+      prepTime: null,
+      totalTime: null,
+      keywords: [],
+      nutrition: { calories: 0, fat: 0, carbs: 0, protein: 0 },
+    };
+
+    const { normalizeRecipeFromJson } = await import("@/server/parser/normalize");
+
+    vi.mocked(normalizeRecipeFromJson).mockResolvedValue({
+      name: "Test Recipe",
+      description: "Test",
+      url: null,
+      image: undefined,
+      servings: undefined,
+      prepMinutes: undefined,
+      cookMinutes: undefined,
+      totalMinutes: undefined,
+      calories: null,
+      fat: null,
+      carbs: null,
+      protein: null,
+      recipeIngredients: [],
+      steps: [{ step: "Mix well", order: 1, systemUsed: "metric", images: [] }],
+      systemUsed: "metric",
+      tags: [],
+      images: [],
+    } as any);
+
+    const result = await normalizeExtractionOutput(output);
+
+    const usSteps = result?.steps?.filter((s) => s.systemUsed === "us");
+
+    expect(usSteps).toHaveLength(2);
+    expect(usSteps?.[0].step).toContain("°"); // degree symbol
+    expect(usSteps?.[0].step).toContain("–"); // en dash
+    expect(usSteps?.[0].step).toContain("use convection"); // comment preserved
+    expect(usSteps?.[0].step).not.toContain("&#176;");
+    expect(usSteps?.[0].step).not.toContain("&#8211;");
+    expect(usSteps?.[1].step).toContain("'"); // apostrophe
+    expect(usSteps?.[1].step).toContain("don't rush");
+    expect(usSteps?.[1].step).not.toContain("&#39;");
+  });
+
+  it("decodes multiple entity types in US content", async () => {
+    const output: RecipeExtractionOutput = {
+      "@context": "https://schema.org",
+      "@type": "Recipe",
+      name: "Test Recipe",
+      description: "Test",
+      recipeIngredient: {
+        metric: ["100g flour"],
+        us: ["1 cup &#8220;baker&#39;s&#8221; flour &#8211; premium grade"],
+      },
+      recipeInstructions: {
+        metric: ["Mix"],
+        us: ["It&#39;s ready when it&#8217;s smooth &#8211; about 5 minutes"],
+      },
+      recipeYield: "4",
+      cookTime: null,
+      prepTime: null,
+      totalTime: null,
+      keywords: [],
+      nutrition: { calories: 0, fat: 0, carbs: 0, protein: 0 },
+    };
+
+    const { normalizeRecipeFromJson } = await import("@/server/parser/normalize");
+
+    vi.mocked(normalizeRecipeFromJson).mockResolvedValue({
+      name: "Test Recipe",
+      description: "Test",
+      url: null,
+      image: undefined,
+      servings: undefined,
+      prepMinutes: undefined,
+      cookMinutes: undefined,
+      totalMinutes: undefined,
+      calories: null,
+      fat: null,
+      carbs: null,
+      protein: null,
+      recipeIngredients: [],
+      steps: [],
+      systemUsed: "metric",
+      tags: [],
+      images: [],
+    } as any);
+
+    const result = await normalizeExtractionOutput(output);
+
+    const usIngredient = result?.recipeIngredients?.find((ing) => ing.systemUsed === "us");
+
+    expect(usIngredient?.ingredientName).toContain("\u201C"); // left double quote
+    expect(usIngredient?.ingredientName).toContain("'"); // apostrophe
+    expect(usIngredient?.ingredientName).toContain("\u201D"); // right double quote
+    expect(usIngredient?.ingredientName).toContain("–"); // en dash
+    expect(usIngredient?.ingredientName).toContain("premium grade");
+
+    const usStep = result?.steps?.find((s) => s.systemUsed === "us");
+
+    expect(usStep?.step).toContain("'"); // apostrophe (It's)
+    expect(usStep?.step).toContain("\u2019"); // right single quote (it's)
+    expect(usStep?.step).toContain("–"); // en dash
+    expect(usStep?.step).toContain("about 5 minutes");
+  });
+
+  it("handles US ingredients without entities", async () => {
+    const output: RecipeExtractionOutput = {
+      "@context": "https://schema.org",
+      "@type": "Recipe",
+      name: "Test Recipe",
+      description: "Test",
+      recipeIngredient: {
+        metric: ["100g flour"],
+        us: ["1 cup flour", "2 eggs"],
+      },
+      recipeInstructions: {
+        metric: ["Mix well"],
+        us: ["Mix well"],
+      },
+      recipeYield: "4",
+      cookTime: null,
+      prepTime: null,
+      totalTime: null,
+      keywords: [],
+      nutrition: { calories: 0, fat: 0, carbs: 0, protein: 0 },
+    };
+
+    const { normalizeRecipeFromJson } = await import("@/server/parser/normalize");
+
+    vi.mocked(normalizeRecipeFromJson).mockResolvedValue({
+      name: "Test Recipe",
+      description: "Test",
+      url: null,
+      image: undefined,
+      servings: undefined,
+      prepMinutes: undefined,
+      cookMinutes: undefined,
+      totalMinutes: undefined,
+      calories: null,
+      fat: null,
+      carbs: null,
+      protein: null,
+      recipeIngredients: [],
+      steps: [],
+      systemUsed: "metric",
+      tags: [],
+      images: [],
+    } as any);
+
+    const result = await normalizeExtractionOutput(output);
+
+    const usIngredients = result?.recipeIngredients?.filter((ing) => ing.systemUsed === "us");
+
+    expect(usIngredients).toHaveLength(2);
+    // Plain text should pass through unchanged
+    expect(usIngredients?.[0].ingredientName).toBe("flour");
+    expect(usIngredients?.[1].ingredientName).toContain("egg");
+  });
+});

--- a/__tests__/server/parser/normalize.test.ts
+++ b/__tests__/server/parser/normalize.test.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { normalizeRecipeFromJson } from "@/server/parser/normalize";
+
+// Mock dependencies
+vi.mock("@/server/downloader", () => ({
+  downloadAllImagesFromJsonLd: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("@/config/server-config-loader", () => ({
+  getUnits: vi.fn().mockResolvedValue({}),
+}));
+
+describe("normalizeRecipeFromJson - HTML Entity Decoding", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("ingredient HTML entity decoding", () => {
+    it("decodes en dash (&#8211;) in ingredient array and keeps comments", async () => {
+      const json = {
+        name: "Test Recipe",
+        recipeIngredient: [
+          "1 cup plain Greek Yogurt &#8211; I used nonfat",
+          "1/2 English cucumber &#8211; seeds removed",
+        ],
+        recipeInstructions: ["Mix well"],
+      };
+
+      const result = await normalizeRecipeFromJson(json);
+
+      expect(result).toBeTruthy();
+      expect(result?.recipeIngredients).toHaveLength(2);
+      // Should decode entity and keep comment
+      expect(result?.recipeIngredients[0].ingredientName).toContain("–"); // en dash
+      expect(result?.recipeIngredients[0].ingredientName).toContain("nonfat");
+      expect(result?.recipeIngredients[0].ingredientName).not.toContain("&#8211;");
+      expect(result?.recipeIngredients[1].ingredientName).toContain("–");
+      expect(result?.recipeIngredients[1].ingredientName).toContain("seeds removed");
+    });
+
+    it("decodes apostrophe (&#39;) in ingredients", async () => {
+      const json = {
+        name: "Test Recipe",
+        recipeIngredient: ["2 cups baker&#39;s sugar"],
+        recipeInstructions: ["Mix"],
+      };
+
+      const result = await normalizeRecipeFromJson(json);
+
+      expect(result?.recipeIngredients[0].ingredientName).toContain("'");
+      expect(result?.recipeIngredients[0].ingredientName).not.toContain("&#39;");
+    });
+
+    it("decodes smart quotes (&#8220;/&#8221;) in ingredients", async () => {
+      const json = {
+        name: "Test Recipe",
+        recipeIngredient: ['1 cup &#8220;raw&#8221; sugar'],
+        recipeInstructions: ["Mix"],
+      };
+
+      const result = await normalizeRecipeFromJson(json);
+
+      expect(result?.recipeIngredients[0].ingredientName).toContain("\u201C");
+      expect(result?.recipeIngredients[0].ingredientName).toContain("\u201D");
+      expect(result?.recipeIngredients[0].ingredientName).not.toContain("&#8220;");
+    });
+
+    it("decodes multiple entity types in single ingredient", async () => {
+      const json = {
+        name: "Test Recipe",
+        recipeIngredient: ["1 cup &#8220;baker&#39;s&#8221; flour &#8211; sifted"],
+        recipeInstructions: ["Mix"],
+      };
+
+      const result = await normalizeRecipeFromJson(json);
+
+      expect(result?.recipeIngredients[0].ingredientName).toContain("\u201C");
+      expect(result?.recipeIngredients[0].ingredientName).toContain("'");
+      expect(result?.recipeIngredients[0].ingredientName).toContain("–");
+      expect(result?.recipeIngredients[0].ingredientName).toContain("sifted");
+    });
+
+    it("handles string ingredient (not array) with entities", async () => {
+      const json = {
+        name: "Test Recipe",
+        recipeIngredient: "1 cup flour &#8211; sifted",
+        recipeInstructions: ["Mix"],
+      };
+
+      const result = await normalizeRecipeFromJson(json);
+
+      expect(result?.recipeIngredients[0].ingredientName).toContain("–");
+      expect(result?.recipeIngredients[0].ingredientName).toContain("sifted");
+    });
+
+    it("preserves ingredients without entities", async () => {
+      const json = {
+        name: "Test Recipe",
+        recipeIngredient: ["1 cup flour", "2 eggs"],
+        recipeInstructions: ["Mix"],
+      };
+
+      const result = await normalizeRecipeFromJson(json);
+
+      expect(result?.recipeIngredients[0].ingredientName).toBe("flour");
+      expect(result?.recipeIngredients[1].ingredientName).toContain("egg");
+    });
+
+    it("decodes degree symbol (&#176;) in ingredients", async () => {
+      const json = {
+        name: "Test Recipe",
+        recipeIngredient: ["Water heated to 180&#176;F"],
+        recipeInstructions: ["Mix"],
+      };
+
+      const result = await normalizeRecipeFromJson(json);
+
+      expect(result?.recipeIngredients[0].ingredientName).toContain("°");
+      expect(result?.recipeIngredients[0].ingredientName).not.toContain("&#176;");
+    });
+  });
+
+  describe("step HTML entity decoding", () => {
+    it("decodes en dash (&#8211;) in instruction strings", async () => {
+      const json = {
+        name: "Test Recipe",
+        recipeIngredient: ["1 cup flour"],
+        recipeInstructions: [
+          "Preheat oven to 350&#176;F &#8211; use convection if available",
+        ],
+      };
+
+      const result = await normalizeRecipeFromJson(json);
+
+      expect(result?.steps).toHaveLength(1);
+      expect(result?.steps[0].step).toContain("–");
+      expect(result?.steps[0].step).toContain("°");
+      expect(result?.steps[0].step).toContain("use convection if available");
+      expect(result?.steps[0].step).not.toContain("&#8211;");
+      expect(result?.steps[0].step).not.toContain("&#176;");
+    });
+
+    it("decodes entities in HowToStep text field", async () => {
+      const json = {
+        name: "Test Recipe",
+        recipeIngredient: ["1 cup flour"],
+        recipeInstructions: [
+          {
+            "@type": "HowToStep",
+            text: "Mix until it&#39;s smooth &#8211; about 2 minutes",
+          },
+        ],
+      };
+
+      const result = await normalizeRecipeFromJson(json);
+
+      expect(result?.steps[0].step).toContain("'");
+      expect(result?.steps[0].step).toContain("–");
+      expect(result?.steps[0].step).toContain("about 2 minutes");
+      expect(result?.steps[0].step).not.toContain("&#39;");
+    });
+
+    it("decodes entities in HowToStep name field", async () => {
+      const json = {
+        name: "Test Recipe",
+        recipeIngredient: ["1 cup flour"],
+        recipeInstructions: [
+          {
+            "@type": "HowToStep",
+            name: "Heat oven to 180&#176;C &#8211; gas mark 4",
+          },
+        ],
+      };
+
+      const result = await normalizeRecipeFromJson(json);
+
+      expect(result?.steps[0].step).toContain("°");
+      expect(result?.steps[0].step).toContain("–");
+      expect(result?.steps[0].step).toContain("gas mark 4");
+    });
+
+    it("decodes entities in nested HowToStep structures", async () => {
+      const json = {
+        name: "Test Recipe",
+        recipeIngredient: ["1 cup flour"],
+        recipeInstructions: {
+          "@type": "HowToSection",
+          itemListElement: [
+            {
+              "@type": "HowToStep",
+              text: "Bake for 30&#8211;35 minutes",
+            },
+          ],
+        },
+      };
+
+      const result = await normalizeRecipeFromJson(json);
+
+      expect(result?.steps[0].step).toContain("–");
+      expect(result?.steps[0].step).not.toContain("&#8211;");
+    });
+
+    it("handles mixed string and object instructions", async () => {
+      const json = {
+        name: "Test Recipe",
+        recipeIngredient: ["1 cup flour"],
+        recipeInstructions: [
+          "Preheat oven &#8211; 350&#176;F",
+          {
+            "@type": "HowToStep",
+            text: "Mix it&#39;s all together",
+          },
+        ],
+      };
+
+      const result = await normalizeRecipeFromJson(json);
+
+      expect(result?.steps).toHaveLength(2);
+      expect(result?.steps[0].step).toContain("–");
+      expect(result?.steps[0].step).toContain("°");
+      expect(result?.steps[1].step).toContain("'");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles empty ingredients array", async () => {
+      const json = {
+        name: "Test Recipe",
+        recipeIngredient: [],
+        recipeInstructions: ["Mix"],
+      };
+
+      const result = await normalizeRecipeFromJson(json);
+
+      expect(result?.recipeIngredients).toHaveLength(0);
+    });
+
+    it("handles missing recipeIngredient field", async () => {
+      const json = {
+        name: "Test Recipe",
+        recipeInstructions: ["Mix"],
+      };
+
+      const result = await normalizeRecipeFromJson(json);
+
+      expect(result?.recipeIngredients).toHaveLength(0);
+    });
+
+    it("handles null/undefined ingredient values", async () => {
+      const json = {
+        name: "Test Recipe",
+        recipeIngredient: [null, undefined, "", "1 cup flour"],
+        recipeInstructions: ["Mix"],
+      };
+
+      const result = await normalizeRecipeFromJson(json);
+
+      expect(result?.recipeIngredients.length).toBeGreaterThan(0);
+    });
+
+    it("decodes numeric entities (&#NNN;)", async () => {
+      const json = {
+        name: "Test Recipe",
+        recipeIngredient: ["100g sm&#248;r"],
+        recipeInstructions: ["R&#248;r godt"],
+      };
+
+      const result = await normalizeRecipeFromJson(json);
+
+      expect(result?.recipeIngredients[0].ingredientName).toContain("ø");
+      expect(result?.steps[0].step).toContain("ø");
+    });
+
+    it("decodes hex entities (&#xHH;)", async () => {
+      const json = {
+        name: "Test Recipe",
+        recipeIngredient: ["caf&#xe9; au lait"],
+        recipeInstructions: ["Enjoy your caf&#xe9;"],
+      };
+
+      const result = await normalizeRecipeFromJson(json);
+
+      expect(result?.recipeIngredients[0].ingredientName).toContain("é");
+      expect(result?.steps[0].step).toContain("é");
+    });
+
+    it("handles named HTML entities", async () => {
+      const json = {
+        name: "Test Recipe",
+        recipeIngredient: ["Salt &amp; Pepper"],
+        recipeInstructions: ["Mix &lt; 5 minutes"],
+      };
+
+      const result = await normalizeRecipeFromJson(json);
+
+      expect(result?.recipeIngredients[0].ingredientName).toContain("&");
+      expect(result?.steps[0].step).toContain("<");
+    });
+  });
+});

--- a/server/ai/features/recipe-extraction/normalizer.ts
+++ b/server/ai/features/recipe-extraction/normalizer.ts
@@ -10,6 +10,7 @@ import type { FullRecipeInsertDTO } from "@/types/dto/recipe";
 
 import { normalizeRecipeFromJson } from "@/server/parser/normalize";
 import { parseIngredientWithDefaults } from "@/lib/helpers";
+import { decode } from "html-entities";
 import { getUnits } from "@/config/server-config-loader";
 import { aiLogger } from "@/server/logger";
 
@@ -124,9 +125,12 @@ export async function normalizeExtractionOutput(
 
   // Parse US ingredients and steps
   const units = await getUnits();
-  const usIngredients = parseIngredientWithDefaults(output.recipeIngredient.us, units);
+  const usIngredients = parseIngredientWithDefaults(
+    output.recipeIngredient.us.map((ing: string) => decode(ing)),
+    units
+  );
   const usSteps = output.recipeInstructions.us.map((step: string, i: number) => ({
-    step,
+    step: decode(step),
     order: i + 1,
     systemUsed: "us" as const,
   }));

--- a/server/parser/normalize.ts
+++ b/server/parser/normalize.ts
@@ -1,4 +1,5 @@
 import { parseIsoDuration, parseIngredientWithDefaults } from "@/lib/helpers";
+import { decode } from "html-entities";
 import { downloadAllImagesFromJsonLd } from "@/server/downloader";
 import { FullRecipeInsertDTO } from "@/types/dto/recipe";
 import { inferSystemUsedFromParsed } from "@/lib/determine-recipe-system";
@@ -56,11 +57,11 @@ export async function normalizeRecipeFromJson(json: any): Promise<FullRecipeInse
   const ingSource = json.recipeIngredient ?? json.ingredients;
   const ingredients = Array.isArray(ingSource)
     ? parseIngredientWithDefaults(
-        ingSource.map((v: any) => v?.toString() || "").filter(Boolean),
+        ingSource.map((v: any) => decode(v?.toString() || "")).filter(Boolean),
         units
       )
     : typeof ingSource === "string"
-      ? parseIngredientWithDefaults(ingSource.toString(), units)
+      ? parseIngredientWithDefaults(decode(ingSource.toString()), units)
       : [];
 
   const systemUsed = inferSystemUsedFromParsed(ingredients);
@@ -71,7 +72,7 @@ export async function normalizeRecipeFromJson(json: any): Promise<FullRecipeInse
     if (!node) return;
 
     if (typeof node === "string") {
-      const s = node.trim();
+      const s = decode(node).trim();
 
       if (s) rawSteps.push(s);
 
@@ -100,7 +101,7 @@ export async function normalizeRecipeFromJson(json: any): Promise<FullRecipeInse
           : item && typeof item.name === "string"
             ? item.name
             : undefined;
-      const chosen = (text || name || "").toString().trim();
+      const chosen = decode((text || name || "").toString()).trim();
 
       if (chosen) {
         if (


### PR DESCRIPTION
This fixes JSON-LD imports where the text is encoded. It corrently drops those receipies:
 
```
recipeIngredient": [
	"1 cup plain Greek Yogurt &#8211; I used nonfat plain greek yogurt",
	"1/2 English cucumber (about 2/3 cup) &#8211; seeds removed, diced into small pieces",
	"2 teaspoons olive oil",
	"3 tablespoons fresh lemon juice",
	"1 tablespoon fresh lemon zest",
	"1 tablespoon minced garlic &#8211; about 1 clove",
	"1/4 cup fresh chopped dill",
	"1/2 teaspoon kosher salt",
	"1/4 teaspoon ground black pepper"
]
```

source: https://pinchmegood.com/easy-10-minute-healthy-tzatziki-sauce/