### PR TITLE
build: add OCI image source label

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -87,6 +87,8 @@ RUN pnpm run build && \
 ##############################
 FROM base AS runtime
 
+LABEL org.opencontainers.image.source="https://github.com/norish-recipes/norish"
+
 ARG YT_DLP_VERSION=2025.11.12
 
 # Security: upgrade all packages first, then install runtime deps


### PR DESCRIPTION
Adds an image label for the source.
This will allow Renovate to automatically fetch the changelog when opening PRs that update the norish image.

More information here:
- https://docs.renovatebot.com/modules/datasource/docker/#description
- https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images