### PR TITLE
chore: Update parse-ingredient version to 1.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "next-themes": "0.4.6",
     "openai": "5.23.2",
     "openid-client": "6.8.1",
-    "parse-ingredient": "1.3.1",
+    "parse-ingredient": "1.3.2",
     "pino-pretty": "^13.1.3",
     "postcss": "^8.5.6",
     "prettier": "^3.7.4",


### PR DESCRIPTION
v1.3.2 fixes a bug where unicode characters would mess up the unit of measurement parsing.