### PR TITLE
chore: Update parse-ingredient version to 1.3.2 in pnpm-lock.yaml

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -289,8 +289,8 @@ importers:
         specifier: 6.8.1
         version: 6.8.1
       parse-ingredient:
-        specifier: 1.3.1
-        version: 1.3.1
+        specifier: 1.3.2
+        version: 1.3.2
       pino-pretty:
         specifier: ^13.1.3
         version: 13.1.3


### PR DESCRIPTION
forgot to also update the version in pnpm-lock,yaml in the previous commit.