### PR TITLE
chore: upgrade parse-ingredient to v1.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "next-themes": "0.4.6",
     "openai": "5.23.2",
     "openid-client": "6.8.1",
-    "parse-ingredient": "1.3.2",
+    "parse-ingredient": "1.3.3",
     "pino-pretty": "^13.1.3",
     "postcss": "^8.5.6",
     "prettier": "^3.7.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -292,8 +292,8 @@ importers:
         specifier: 6.8.1
         version: 6.8.1
       parse-ingredient:
-        specifier: 1.3.2
-        version: 1.3.2
+        specifier: 1.3.3
+        version: 1.3.3
       pino-pretty:
         specifier: ^13.1.3
         version: 13.1.3
@@ -426,6 +426,10 @@ packages:
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@7.28.6':
+    resolution: {integrity: sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/compat-data@7.28.5':
     resolution: {integrity: sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==}
     engines: {node: '>=6.9.0'}
@@ -495,6 +499,10 @@ packages:
 
   '@babel/runtime@7.28.4':
     resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.28.6':
+    resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.27.2':
@@ -5324,8 +5332,8 @@ packages:
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
-  parse-ingredient@1.3.2:
-    resolution: {integrity: sha512-8fSX9Va9DJGJ4RZcUZGI00pp8bbWRoMACCtjgn2x+EKfYTSo/c8/WvWxSLTNlhAwyjkyXEyrxIayJpMFqj1UEQ==}
+  parse-ingredient@1.3.3:
+    resolution: {integrity: sha512-AjhsdCtkzUorAOfcEVGDRnS8lAZnS9ycAeU25IPGUcXwjlgKezwFG3ePnfqIdk3sZPIPl6+9yda0vbE0aUr2sg==}
     engines: {node: '>=10'}
 
   parse5-htmlparser2-tree-adapter@7.1.0:
@@ -6572,6 +6580,12 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/code-frame@7.28.6':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
   '@babel/compat-data@7.28.5': {}
 
   '@babel/core@7.28.5':
@@ -6656,6 +6670,8 @@ snapshots:
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/runtime@7.28.4': {}
+
+  '@babel/runtime@7.28.6': {}
 
   '@babel/template@7.27.2':
     dependencies:
@@ -9536,8 +9552,8 @@ snapshots:
 
   '@testing-library/dom@10.4.1':
     dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/runtime': 7.28.4
+      '@babel/code-frame': 7.28.6
+      '@babel/runtime': 7.28.6
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
       dom-accessibility-api: 0.5.16
@@ -12075,7 +12091,7 @@ snapshots:
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
 
-  parse-ingredient@1.3.2:
+  parse-ingredient@1.3.3:
     dependencies:
       numeric-quantity: 2.1.0
 


### PR DESCRIPTION
Changes in v1.3.3:
- Unicode support in more regexes, i.e., for trailing UOMs
- UOMs are now case insensitive; capitalization variants in UOM lists are now obsolete