### PR TITLE
fix: use pino-pretty transport instead of pipe

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "packageManager": "pnpm@10.27.0",
   "scripts": {
-    "dev": "tsx watch server.ts | pnpm exec pino-pretty",
+    "dev": "tsx watch server.ts",
     "build": "next build && pnpm run build:server && pnpm run update-sw",
     "build:server": "tsdown",
     "update-sw": "node scripts/update-sw-version.js",

--- a/server/logger.ts
+++ b/server/logger.ts
@@ -27,7 +27,10 @@ const logLevel: LogLevel =
  * Development: Pipe output through pino-pretty in dev script
  * Production: Plain JSON to stdout for log aggregation
  */
-const logger = pino({ level: logLevel });
+const logger = pino({
+  level: logLevel,
+  transport: isDev ? { target: "pino-pretty", options: { colorize: true } } : undefined,
+});
 
 export { logger };
 


### PR DESCRIPTION
The piped pino-pretty was causing issues in my terminal after exiting the `dev` command. I removed the pipe in favor of setting `transport` in the pino config.