### PR TITLE
fix: untoggle wake lock

### DIFF
--- a/app/(app)/recipes/[id]/components/wake-lock-toggle.tsx
+++ b/app/(app)/recipes/[id]/components/wake-lock-toggle.tsx
@@ -15,7 +15,7 @@ export default function WakeLockToggle() {
     if (isSupported && !isActive) {
       toggle();
     }
-  }, [isSupported, isActive, toggle]);
+  }, []);
 
   if (!isSupported) {
     return (


### PR DESCRIPTION
Removed the loop that caused the switch to retoggle everytime.

Fixes #225 
