### PR TITLE
fix(i18n): translation for filter mode

### DIFF
--- a/i18n/messages/de-formal/common.json
+++ b/i18n/messages/de-formal/common.json
@@ -42,7 +42,7 @@
     "title": "Filter",
     "search": "Suchen",
     "sort": "Sortieren",
-    "mode": "Modus",
+    "mode": "Übereinstimmung",
     "modeAll": "Alle",
     "modeAny": "Beliebig",
     "tags": "Tags",

--- a/i18n/messages/de-informal/common.json
+++ b/i18n/messages/de-informal/common.json
@@ -42,7 +42,7 @@
     "title": "Filter",
     "search": "Suchen",
     "sort": "Sortieren",
-    "mode": "Modus",
+    "mode": "Übereinstimmung",
     "modeAll": "Alle",
     "modeAny": "Beliebig",
     "tags": "Tags",


### PR DESCRIPTION
Changed the german translation for the `mode` label from "Modus" to "Übereinstimmung" to better reflect its intended meaning in the filter context.