### PR TITLE
feat: cooking time filter

### DIFF
--- a/__tests__/trpc/recipes/permissions-integration.test.ts
+++ b/__tests__/trpc/recipes/permissions-integration.test.ts
@@ -423,6 +423,7 @@ describe("recipe permission enforcement", () => {
               input.filterMode,
               input.sortMode,
               input.minRating,
+              input.maxCookingTime,
               input.categories
             );
 
@@ -442,6 +443,7 @@ describe("recipe permission enforcement", () => {
         },
         50,
         0,
+        undefined,
         undefined,
         undefined,
         undefined,

--- a/__tests__/trpc/recipes/recipes.test.ts
+++ b/__tests__/trpc/recipes/recipes.test.ts
@@ -78,6 +78,7 @@ describe("recipes procedures", () => {
               input.filterMode,
               input.sortMode,
               input.minRating,
+              input.maxCookingTime,
               input.categories
             );
 
@@ -114,6 +115,7 @@ describe("recipes procedures", () => {
         "OR",
         "dateDesc",
         undefined,
+        undefined,
         ["Breakfast", "Dinner"]
       );
       expect(result.recipes).toEqual(mockRecipes);
@@ -149,6 +151,7 @@ describe("recipes procedures", () => {
               input.filterMode,
               input.sortMode,
               input.minRating,
+              input.maxCookingTime,
               input.categories
             );
 
@@ -172,6 +175,7 @@ describe("recipes procedures", () => {
         },
         50,
         0,
+        undefined,
         undefined,
         undefined,
         undefined,
@@ -212,6 +216,7 @@ describe("recipes procedures", () => {
               input.filterMode,
               input.sortMode,
               input.minRating,
+              input.maxCookingTime,
               input.categories
             );
 
@@ -234,6 +239,7 @@ describe("recipes procedures", () => {
         },
         50,
         0,
+        undefined,
         undefined,
         undefined,
         undefined,

--- a/components/Panel/consumers/filters-panel.tsx
+++ b/components/Panel/consumers/filters-panel.tsx
@@ -1,26 +1,34 @@
 "use client";
 
+import type { FilterMode, RecipeCategory, SortOrder } from "@/types";
+
 import {
-  MagnifyingGlassIcon,
+  ArrowPathIcon,
   ArrowRightIcon,
   CheckIcon,
-  ArrowPathIcon,
   HeartIcon,
+  MagnifyingGlassIcon,
 } from "@heroicons/react/16/solid";
-import { Input, Button, Chip } from "@heroui/react";
+import { Button, Chip, Input } from "@heroui/react";
 import { motion } from "motion/react";
-import { useState, useCallback, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
 
+import Panel from "@/components/Panel/Panel";
+import SearchFieldToggles from "@/components/dashboard/search-field-toggles";
+import ChipSkeleton from "@/components/skeleton/chip-skeleton";
+import RatingStars from "@/components/shared/rating-stars";
 import { useRecipesFiltersContext } from "@/context/recipes-filters-context";
 import { useTagsQuery } from "@/hooks/config";
-import ChipSkeleton from "@/components/skeleton/chip-skeleton";
-import Panel from "@/components/Panel/Panel";
-import RatingStars from "@/components/shared/rating-stars";
-import SearchFieldToggles from "@/components/dashboard/search-field-toggles";
-import { RecipeCategory } from "@/types";
 
 const ALL_CATEGORIES: RecipeCategory[] = ["Breakfast", "Lunch", "Dinner", "Snack"];
+
+const COOKING_TIME_OPTIONS: Array<{ value: number; labelKey: string }> = [
+  { value: 15, labelKey: "cookingTimeUnder15" },
+  { value: 30, labelKey: "cookingTimeUnder30" },
+  { value: 60, labelKey: "cookingTimeUnder60" },
+  { value: 120, labelKey: "cookingTimeUnder120" },
+];
 
 type FiltersPanelProps = {
   open: boolean;
@@ -36,11 +44,14 @@ function FiltersPanelContent({ onOpenChange }: { onOpenChange: (open: boolean) =
   const [tagFilter, setTagFilter] = useState("");
   const [workingTags, setWorkingTags] = useState<string[]>(filters.searchTags);
   const [workingCategories, setWorkingCategories] = useState<RecipeCategory[]>(filters.categories);
-  const [localFilterMode, setLocalFilterMode] = useState(filters.filterMode);
-  const [localSortMode, setLocalSortMode] = useState(filters.sortMode);
+  const [localFilterMode, setLocalFilterMode] = useState<FilterMode>(filters.filterMode);
+  const [localSortMode, setLocalSortMode] = useState<SortOrder>(filters.sortMode);
   const [localInput, setLocalInput] = useState(filters.rawInput);
   const [localFavoritesOnly, setLocalFavoritesOnly] = useState(filters.showFavoritesOnly);
   const [localMinRating, setLocalMinRating] = useState<number | null>(filters.minRating);
+  const [localMaxCookingTime, setLocalMaxCookingTime] = useState<number | null>(
+    filters.maxCookingTime ?? null
+  );
 
   const { tags: allTags, isLoading } = useTagsQuery();
 
@@ -52,6 +63,7 @@ function FiltersPanelContent({ onOpenChange }: { onOpenChange: (open: boolean) =
     setLocalInput(filters.rawInput);
     setLocalFavoritesOnly(filters.showFavoritesOnly);
     setLocalMinRating(filters.minRating);
+    setLocalMaxCookingTime(filters.maxCookingTime ?? null);
   }, [filters]);
 
   const toggleTag = useCallback((tag: string) => {
@@ -64,9 +76,13 @@ function FiltersPanelContent({ onOpenChange }: { onOpenChange: (open: boolean) =
     );
   }, []);
 
+  const toggleCookingTime = useCallback((value: number) => {
+    setLocalMaxCookingTime((prev) => (prev === value ? null : value));
+  }, []);
+
   const decideSortOrder = (type: "title" | "date") => {
-    const asc = (type + "Asc") as typeof localSortMode;
-    const desc = (type + "Desc") as typeof localSortMode;
+    const asc = `${type}Asc` as SortOrder;
+    const desc = `${type}Desc` as SortOrder;
 
     if (localSortMode === asc) {
       setLocalSortMode(desc);
@@ -84,7 +100,20 @@ function FiltersPanelContent({ onOpenChange }: { onOpenChange: (open: boolean) =
 
   const close = useCallback(() => onOpenChange(false), [onOpenChange]);
 
-  const apply = () => {
+  const handleReset = useCallback(() => {
+    clearFilters();
+    setWorkingTags([]);
+    setWorkingCategories([]);
+    setLocalFilterMode("AND");
+    setLocalSortMode("dateDesc");
+    setLocalInput("");
+    setLocalFavoritesOnly(false);
+    setLocalMinRating(null);
+    setLocalMaxCookingTime(null);
+    close();
+  }, [clearFilters, close]);
+
+  const apply = useCallback(() => {
     setFilters({
       searchTags: [...workingTags],
       categories: [...workingCategories],
@@ -93,10 +122,22 @@ function FiltersPanelContent({ onOpenChange }: { onOpenChange: (open: boolean) =
       rawInput: localInput,
       showFavoritesOnly: localFavoritesOnly,
       minRating: localMinRating,
+      maxCookingTime: localMaxCookingTime,
     });
 
     close();
-  };
+  }, [
+    setFilters,
+    workingTags,
+    workingCategories,
+    localFilterMode,
+    localSortMode,
+    localInput,
+    localFavoritesOnly,
+    localMinRating,
+    localMaxCookingTime,
+    close,
+  ]);
 
   return (
     <div className="flex flex-col gap-6">
@@ -177,7 +218,7 @@ function FiltersPanelContent({ onOpenChange }: { onOpenChange: (open: boolean) =
               size="sm"
               startContent={<CheckIcon className="size-3.5" />}
               variant={localFilterMode === value ? "solid" : "flat"}
-              onPress={() => setLocalFilterMode(value as any)}
+              onPress={() => setLocalFilterMode(value as FilterMode)}
             >
               {label}
             </Button>
@@ -204,6 +245,32 @@ function FiltersPanelContent({ onOpenChange }: { onOpenChange: (open: boolean) =
           </Button>
 
           <RatingStars value={localMinRating} onChange={setLocalMinRating} />
+        </div>
+      </section>
+
+      {/* Cooking time */}
+      <section>
+        <h3 className="text-default-500 mb-2 text-[11px] font-medium tracking-wide uppercase">
+          {t("cookingTime")}
+        </h3>
+        <div className="flex flex-wrap gap-2">
+          {COOKING_TIME_OPTIONS.map(({ value, labelKey }) => {
+            const active = localMaxCookingTime === value;
+
+            return (
+              <Button
+                key={value}
+                className="h-9 px-3 text-xs"
+                color={active ? "primary" : "default"}
+                radius="full"
+                size="sm"
+                variant={active ? "solid" : "flat"}
+                onPress={() => toggleCookingTime(value)}
+              >
+                {t(labelKey)}
+              </Button>
+            );
+          })}
         </div>
       </section>
 
@@ -288,17 +355,7 @@ function FiltersPanelContent({ onOpenChange }: { onOpenChange: (open: boolean) =
           size="sm"
           startContent={<ArrowPathIcon className="size-4" />}
           variant="flat"
-          onPress={() => {
-            clearFilters();
-            setWorkingTags([]);
-            setWorkingCategories([]);
-            setLocalFilterMode("AND");
-            setLocalSortMode("dateDesc");
-            setLocalInput("");
-            setLocalFavoritesOnly(false);
-            setLocalMinRating(null);
-            close();
-          }}
+          onPress={handleReset}
         >
           {tActions("reset")}
         </Button>

--- a/components/shared/filters.tsx
+++ b/components/shared/filters.tsx
@@ -21,9 +21,16 @@ export default function Filters({ isGlass = false }: FiltersProps) {
     const hasTags = filters.searchTags.length > 0;
     const hasCategories = filters.categories.length > 0;
     const hasRating = filters.minRating !== null;
+    const hasCookingTime = filters.maxCookingTime !== null;
 
-    return hasSearch || hasTags || hasCategories || hasRating;
-  }, [filters.rawInput, filters.searchTags, filters.categories, filters.minRating]);
+    return hasSearch || hasTags || hasCategories || hasRating || hasCookingTime;
+  }, [
+    filters.rawInput,
+    filters.searchTags,
+    filters.categories,
+    filters.minRating,
+    filters.maxCookingTime,
+  ]);
 
   return (
     <>

--- a/context/recipes-context.tsx
+++ b/context/recipes-context.tsx
@@ -62,6 +62,7 @@ export function RecipesContextProvider({ children }: { children: ReactNode }) {
       filterMode: filters.filterMode as "AND" | "OR",
       sortMode: filters.sortMode as "titleAsc" | "titleDesc" | "dateAsc" | "dateDesc",
       minRating: filters.minRating ?? undefined,
+      maxCookingTime: filters.maxCookingTime ?? undefined,
     }),
     [filters]
   );
@@ -163,9 +164,10 @@ export function RecipesContextProvider({ children }: { children: ReactNode }) {
     const hasSearch = filters.rawInput.trim().length > 0;
     const hasTags = filters.searchTags.length > 0;
     const hasCategories = filters.categories.length > 0;
+    const hasCookingTime = filters.maxCookingTime !== null;
 
-    return hasSearch || hasTags || hasCategories;
-  }, [filters.rawInput, filters.searchTags, filters.categories]);
+    return hasSearch || hasTags || hasCategories || hasCookingTime;
+  }, [filters.rawInput, filters.searchTags, filters.categories, filters.maxCookingTime]);
 
   const value = useMemo<Ctx>(
     () => ({

--- a/hooks/recipes/use-recipe-filters.ts
+++ b/hooks/recipes/use-recipe-filters.ts
@@ -23,6 +23,7 @@ export type RecipeFilters = {
   sortMode: SortOrder;
   showFavoritesOnly: boolean;
   minRating: number | null;
+  maxCookingTime: number | null;
   categories: RecipeCategory[];
 };
 
@@ -40,6 +41,7 @@ const DEFAULT_PERSISTED: PersistedFilters = {
   sortMode: "dateDesc",
   showFavoritesOnly: false,
   minRating: null,
+  maxCookingTime: null,
   categories: [],
 };
 
@@ -68,6 +70,10 @@ function validateFilters(data: unknown): PersistedFilters | null {
     d.minRating === null || (typeof d.minRating === "number" && d.minRating >= 0)
       ? (d.minRating as number | null)
       : null;
+  const maxCookingTime =
+    d.maxCookingTime === null || (typeof d.maxCookingTime === "number" && d.maxCookingTime > 0)
+      ? (d.maxCookingTime as number | null)
+      : null;
   const categories = Array.isArray(d.categories)
     ? d.categories.filter((c): c is RecipeCategory =>
         VALID_CATEGORIES.includes(c as RecipeCategory)
@@ -84,6 +90,7 @@ function validateFilters(data: unknown): PersistedFilters | null {
     searchFields: searchFields ?? [...DEFAULT_PERSISTED.searchFields],
     showFavoritesOnly: showFavoritesOnly ?? DEFAULT_PERSISTED.showFavoritesOnly,
     minRating: minRating ?? DEFAULT_PERSISTED.minRating,
+    maxCookingTime: maxCookingTime ?? DEFAULT_PERSISTED.maxCookingTime,
     categories: categories ?? DEFAULT_PERSISTED.categories,
   };
 }

--- a/hooks/recipes/use-recipes-query.ts
+++ b/hooks/recipes/use-recipes-query.ts
@@ -21,6 +21,7 @@ export type RecipeFilters = {
   filterMode?: "AND" | "OR";
   sortMode?: "titleAsc" | "titleDesc" | "dateAsc" | "dateDesc";
   minRating?: number;
+  maxCookingTime?: number;
 };
 
 type InfiniteRecipeData = InfiniteData<{
@@ -68,6 +69,7 @@ export function useRecipesQuery(filters: RecipeFilters = {}): RecipesQueryResult
     filterMode = "OR",
     sortMode = "dateDesc",
     minRating,
+    maxCookingTime,
   } = filters;
 
   // Use the dedicated hooks for reading pending state
@@ -86,7 +88,17 @@ export function useRecipesQuery(filters: RecipeFilters = {}): RecipesQueryResult
   } = useRecipesCacheHelpers();
 
   const infiniteQueryOptions = trpc.recipes.list.infiniteQueryOptions(
-    { limit: 100, search, searchFields, tags, categories, filterMode, sortMode, minRating },
+    {
+      limit: 100,
+      search,
+      searchFields,
+      tags,
+      categories,
+      filterMode,
+      sortMode,
+      minRating,
+      maxCookingTime,
+    },
     {
       getNextPageParam: (lastPage) => lastPage.nextCursor,
     }

--- a/i18n/messages/de-formal/common.json
+++ b/i18n/messages/de-formal/common.json
@@ -49,6 +49,11 @@
     "searchTags": "Tags durchsuchen",
     "favoritesAndRating": "Favoriten & Bewertung",
     "favorites": "Favoriten",
+    "cookingTime": "Kochzeit",
+    "cookingTimeUnder15": "<15 Min",
+    "cookingTimeUnder30": "<30 Min",
+    "cookingTimeUnder60": "<60 Min",
+    "cookingTimeUnder120": "<120 Min",
     "categories": "Kategorien",
     "category": {
       "breakfast": "Frühstück",

--- a/i18n/messages/de-informal/common.json
+++ b/i18n/messages/de-informal/common.json
@@ -49,6 +49,11 @@
     "searchTags": "Tags durchsuchen",
     "favoritesAndRating": "Favoriten & Bewertung",
     "favorites": "Favoriten",
+    "cookingTime": "Kochzeit",
+    "cookingTimeUnder15": "<15 Min",
+    "cookingTimeUnder30": "<30 Min",
+    "cookingTimeUnder60": "<60 Min",
+    "cookingTimeUnder120": "<120 Min",
     "categories": "Kategorien",
     "category": {
       "breakfast": "Frühstück",

--- a/i18n/messages/en/common.json
+++ b/i18n/messages/en/common.json
@@ -49,6 +49,11 @@
     "searchTags": "Search tags",
     "favoritesAndRating": "Favorites & Rating",
     "favorites": "Favorites",
+    "cookingTime": "Cooking time",
+    "cookingTimeUnder15": "<15 min",
+    "cookingTimeUnder30": "<30 min",
+    "cookingTimeUnder60": "<60 min",
+    "cookingTimeUnder120": "<120 min",
     "categories": "Categories",
     "category": {
       "breakfast": "Breakfast",

--- a/i18n/messages/fr/common.json
+++ b/i18n/messages/fr/common.json
@@ -49,6 +49,11 @@
     "searchTags": "Recherche étiquettes",
     "favoritesAndRating": "Favoris et évaluation",
     "favorites": "Favoris",
+    "cookingTime": "Temps de cuisson",
+    "cookingTimeUnder15": "<15 min",
+    "cookingTimeUnder30": "<30 min",
+    "cookingTimeUnder60": "<60 min",
+    "cookingTimeUnder120": "<120 min",
     "categories": "Catégories",
     "category": {
       "breakfast": "Petit-déjeuner",

--- a/i18n/messages/nl/common.json
+++ b/i18n/messages/nl/common.json
@@ -49,6 +49,11 @@
     "searchTags": "Zoek tags",
     "favoritesAndRating": "Favorieten & Beoordeling",
     "favorites": "Favorieten",
+    "cookingTime": "Kooktijd",
+    "cookingTimeUnder15": "<15 min",
+    "cookingTimeUnder30": "<30 min",
+    "cookingTimeUnder60": "<60 min",
+    "cookingTimeUnder120": "<120 min",
     "categories": "Categorieën",
     "category": {
       "breakfast": "Ontbijt",

--- a/server/db/repositories/recipes.ts
+++ b/server/db/repositories/recipes.ts
@@ -1,4 +1,4 @@
-import { eq, ilike, inArray, and, asc, desc, sql, or } from "drizzle-orm";
+import { eq, ilike, inArray, and, asc, desc, lte, sql, or } from "drizzle-orm";
 import z from "zod";
 
 import { db } from "../drizzle";
@@ -246,6 +246,7 @@ export async function listRecipes(
   filterMode: FilterMode = "OR",
   sortMode: SortOrder = "dateDesc",
   minRating?: number,
+  maxCookingTime?: number,
   categories?: RecipeCategory[]
 ): Promise<{ recipes: RecipeDashboardDTO[]; total: number }> {
   const whereConditions: any[] = [];
@@ -385,6 +386,13 @@ export async function listRecipes(
   if (categories?.length) {
     const categoryArray = `{${categories.join(",")}}`;
     whereConditions.push(sql`${recipes.categories} && ${categoryArray}::recipe_category[]`);
+  }
+
+  if (maxCookingTime !== undefined) {
+    const hasTime = sql`(${recipes.totalMinutes} IS NOT NULL OR ${recipes.prepMinutes} IS NOT NULL OR ${recipes.cookMinutes} IS NOT NULL)`;
+    const effectiveMinutes = sql<number>`CASE WHEN ${recipes.totalMinutes} IS NOT NULL THEN ${recipes.totalMinutes} ELSE COALESCE(${recipes.prepMinutes}, 0) + COALESCE(${recipes.cookMinutes}, 0) END`;
+
+    whereConditions.push(and(hasTime, lte(effectiveMinutes, maxCookingTime)));
   }
 
   const whereClause = whereConditions.length ? and(...whereConditions) : undefined;

--- a/server/db/zodSchemas/recipe.ts
+++ b/server/db/zodSchemas/recipe.ts
@@ -90,6 +90,7 @@ export const RecipeListInputSchema = z.object({
   filterMode: z.enum(["AND", "OR"]).default("OR"),
   sortMode: z.enum(["titleAsc", "titleDesc", "dateAsc", "dateDesc"]).default("dateDesc"),
   minRating: z.number().min(1).max(5).optional(),
+  maxCookingTime: z.number().int().min(1).optional(),
 });
 
 export const RecipeGetInputSchema = z.object({

--- a/server/trpc/routers/recipes/recipes.ts
+++ b/server/trpc/routers/recipes/recipes.ts
@@ -128,8 +128,18 @@ async function assertRecipeAccess(
 
 // Procedures
 const list = authedProcedure.input(RecipeListInputSchema).query(async ({ ctx, input }) => {
-  const { cursor, limit, search, searchFields, tags, filterMode, sortMode, minRating, categories } =
-    input;
+  const {
+    cursor,
+    limit,
+    search,
+    searchFields,
+    tags,
+    filterMode,
+    sortMode,
+    minRating,
+    maxCookingTime,
+    categories,
+  } = input;
 
   log.debug({ userId: ctx.user.id, cursor, limit }, "Listing recipes");
 
@@ -149,6 +159,7 @@ const list = authedProcedure.input(RecipeListInputSchema).query(async ({ ctx, in
     filterMode as FilterMode,
     sortMode as SortOrder,
     minRating,
+    maxCookingTime,
     categories
   );
 


### PR DESCRIPTION
* New cooking time filter (#211) to filter recipes by cooking time (total cooking time or, if absent, preparation time + cooking time). Excluding recipes without any time data, when a cooking time filter is active.
<img width="342" height="86" alt="image" src="https://github.com/user-attachments/assets/b7f7e9ea-531b-423d-8042-451445b022a2" />

* Refactored reset-handler for filters to use `useCallback` for better performance.

* i18n support for the new filter.

* Added new filter to test cases.