### PR TITLE
feat: auto scroll mobile steps

### DIFF
--- a/app/(app)/recipes/[id]/components/steps-list.tsx
+++ b/app/(app)/recipes/[id]/components/steps-list.tsx
@@ -1,7 +1,6 @@
 "use client";
-
-import React, { useState } from "react";
-import { CheckIcon } from "@heroicons/react/16/solid";
+import React, { useLayoutEffect, useMemo, useRef, useState } from "react";
+import { CheckIcon } from "@heroicons/react/20/solid";
 import Image from "next/image";
 
 import { useRecipeContext } from "../context";
@@ -10,23 +9,81 @@ import ImageLightbox from "@/components/shared/image-lightbox";
 import SmartMarkdownRenderer from "@/components/shared/smart-markdown-renderer";
 import { SmartInstruction } from "@/components/recipe/smart-instruction";
 
-export default function StepsList() {
+type StepsListProps = {
+  autoScrollOnCheck?: boolean;
+};
+
+export default function StepsList({ autoScrollOnCheck = false }: StepsListProps) {
   const { recipe } = useRecipeContext();
   const [done, setDone] = useState<Set<number>>(() => new Set());
   const [lightboxOpen, setLightboxOpen] = useState(false);
   const [lightboxImages, setLightboxImages] = useState<{ src: string; alt?: string }[]>([]);
   const [lightboxInitialIndex, setLightboxInitialIndex] = useState(0);
+  const [pendingScrollIndex, setPendingScrollIndex] = useState<number | null>(null);
+  const stepRefs = useRef<Map<number, HTMLLIElement | null>>(new Map());
+
+  const filteredSteps = useMemo(() => {
+    return (
+      recipe?.steps
+        .filter((s) => s.systemUsed === recipe.systemUsed)
+        .sort((a, b) => a.order - b.order) ?? []
+    );
+  }, [recipe?.steps, recipe?.systemUsed]);
+
+  const getNextIncompleteStepIndex = (fromIndex: number, doneSet: Set<number>) => {
+    for (let idx = fromIndex + 1; idx < filteredSteps.length; idx++) {
+      const step = filteredSteps[idx];
+
+      if (step.step.trim().startsWith("#")) {
+        continue;
+      }
+
+      if (!doneSet.has(idx)) {
+        return idx;
+      }
+    }
+
+    return null;
+  };
+
+  const scrollToStep = (index: number) => {
+    const target = stepRefs.current.get(index);
+
+    if (!target) {
+      return;
+    }
+
+    target.scrollIntoView({ block: "center", inline: "nearest", behavior: "smooth" });
+  };
 
   const toggle = (i: number) => {
-    setDone((prev) => {
-      const next = new Set(prev);
+    const next = new Set(done);
+    const isCurrentlyDone = next.has(i);
 
-      if (next.has(i)) next.delete(i);
-      else next.add(i);
+    if (isCurrentlyDone) {
+      next.delete(i);
+      setPendingScrollIndex(null);
+    } else {
+      next.add(i);
 
-      return next;
-    });
+      if (autoScrollOnCheck) {
+        setPendingScrollIndex(getNextIncompleteStepIndex(i, next));
+      }
+    }
+
+    setDone(next);
   };
+
+  useLayoutEffect(() => {
+    if (!autoScrollOnCheck || pendingScrollIndex === null) {
+      return;
+    }
+
+    const targetIndex = pendingScrollIndex;
+
+    setPendingScrollIndex(null);
+    requestAnimationFrame(() => scrollToStep(targetIndex));
+  }, [autoScrollOnCheck, pendingScrollIndex]);
 
   const onKeyToggle = (e: React.KeyboardEvent, i: number) => {
     if (e.key === "Enter" || e.key === " ") {
@@ -50,11 +107,6 @@ export default function StepsList() {
     <>
       <ol className="space-y-3">
         {(() => {
-          const filteredSteps =
-            recipe?.steps
-              .filter((s) => s.systemUsed === recipe.systemUsed)
-              .sort((a, b) => a.order - b.order) ?? [];
-
           let stepNumber = 0;
 
           return filteredSteps.map((s, i) => {
@@ -79,7 +131,16 @@ export default function StepsList() {
             const currentStepNumber = stepNumber;
 
             return (
-              <li key={i}>
+              <li
+                key={i}
+                ref={(node) => {
+                  if (node) {
+                    stepRefs.current.set(i, node);
+                  } else {
+                    stepRefs.current.delete(i);
+                  }
+                }}
+              >
                 <div
                   aria-pressed={isDone}
                   className="group hover:bg-default-100 dark:hover:bg-default-100/10 flex cursor-pointer gap-4 rounded-xl p-3 transition-all duration-200 select-none"

--- a/app/(app)/recipes/[id]/components/steps-list.tsx
+++ b/app/(app)/recipes/[id]/components/steps-list.tsx
@@ -53,7 +53,7 @@ export default function StepsList({ autoScrollOnCheck = false }: StepsListProps)
       return;
     }
 
-  target.scrollIntoView({ block: "center", inline: "nearest", behavior: "smooth" });
+  target.scrollIntoView({ behavior: "smooth", block: "start" });
   };
 
   const toggle = (i: number) => {

--- a/app/(app)/recipes/[id]/components/steps-list.tsx
+++ b/app/(app)/recipes/[id]/components/steps-list.tsx
@@ -53,7 +53,7 @@ export default function StepsList({ autoScrollOnCheck = false }: StepsListProps)
       return;
     }
 
-    target.scrollIntoView({ block: "center", inline: "nearest", behavior: "smooth" });
+  target.scrollIntoView({ block: "center", inline: "nearest", behavior: "smooth" });
   };
 
   const toggle = (i: number) => {
@@ -140,6 +140,7 @@ export default function StepsList({ autoScrollOnCheck = false }: StepsListProps)
                     stepRefs.current.delete(i);
                   }
                 }}
+                className="scroll-mt-20"
               >
                 <div
                   aria-pressed={isDone}

--- a/app/(app)/recipes/[id]/recipe-page-mobile.tsx
+++ b/app/(app)/recipes/[id]/recipe-page-mobile.tsx
@@ -241,7 +241,7 @@ export default function RecipePageMobile() {
             </div>
 
             <div className="-mx-1">
-              <StepsList />
+              <StepsList autoScrollOnCheck />
             </div>
 
             {/* Rating Section */}

--- a/openspec/changes/add-mobile-recipe-step-autoscroll/proposal.md
+++ b/openspec/changes/add-mobile-recipe-step-autoscroll/proposal.md
@@ -1,0 +1,13 @@
+# Change: Add mobile recipe step auto-scroll
+
+## Why
+Users cooking on mobile benefit from hands-free progression through preparation steps when they mark a step complete.
+
+## What Changes
+- Add an auto-scroll behavior for recipe preparation steps on mobile when a step is marked complete.
+- Smoothly scroll to the next incomplete step after a check action.
+- Do not auto-scroll on desktop, and do not auto-scroll when a step is unchecked.
+
+## Impact
+- Affected specs: mobile-ui
+- Affected code: recipe step list UI in app/(app)/recipes/[id]/ components

--- a/openspec/changes/add-mobile-recipe-step-autoscroll/specs/mobile-ui/spec.md
+++ b/openspec/changes/add-mobile-recipe-step-autoscroll/specs/mobile-ui/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+### Requirement: Mobile Recipe Step Auto-Scroll
+
+The recipe preparation step list SHALL auto-scroll on mobile when a step is marked complete.
+
+#### Scenario: Step check scrolls to next incomplete step
+- **WHEN** a user on a mobile device checks a preparation step
+- **AND** there is a subsequent step that is not yet checked
+- **THEN** the view SHALL smoothly scroll so the next incomplete step is brought into view
+
+#### Scenario: No auto-scroll on uncheck
+- **WHEN** a user on a mobile device unchecks a preparation step
+- **THEN** the view SHALL NOT auto-scroll
+
+#### Scenario: No auto-scroll when no next step
+- **WHEN** a user on a mobile device checks the last incomplete preparation step
+- **THEN** the view SHALL NOT auto-scroll
+
+#### Scenario: No auto-scroll on desktop
+- **WHEN** a user checks a preparation step on a desktop device
+- **THEN** the view SHALL NOT auto-scroll


### PR DESCRIPTION
QoL: When checking off a recipe step on mobile, it will automatically scroll to the next unchecked step.

Did this last week, but forgot to make a pr for v0.16.0
Maybe this is something that can later be (de-)activated in #284 if you want to merge that too.