### PR TITLE
feat: haptic feedback

### DIFF
--- a/apps/web/app/(app)/recipes/[id]/components/ingredient-list.tsx
+++ b/apps/web/app/(app)/recipes/[id]/components/ingredient-list.tsx
@@ -5,6 +5,7 @@ import { CheckIcon } from "@heroicons/react/20/solid";
 import { formatAmount } from "@norish/shared/lib/format-amount";
 
 import { useRecipeContextRequired } from "../context";
+import { triggerHaptic } from "@/lib/haptics";
 
 import SmartMarkdownRenderer from "@/components/shared/smart-markdown-renderer";
 import { useAmountDisplayPreference } from "@/hooks/use-amount-display-preference";
@@ -22,6 +23,14 @@ export default function IngredientsList() {
   const display = adjustedIngredients?.length > 0 ? adjustedIngredients : recipe.recipeIngredients;
 
   const toggle = (idx: number) => {
+    // Call haptics synchronously in the event handler's call stack so browsers treat it as a user gesture (required by Chrome).
+    try {
+      const adding = !checked.has(idx);
+      triggerHaptic(adding ? "success" : "selection");
+    } catch {
+      // ignore
+    }
+
     setChecked((prev) => {
       const next = new Set(prev);
 

--- a/apps/web/app/(app)/recipes/[id]/components/steps-list.tsx
+++ b/apps/web/app/(app)/recipes/[id]/components/steps-list.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import { CheckIcon } from "@heroicons/react/16/solid";
 
 import { useRecipeContext } from "../context";
+import { triggerHaptic } from "@/lib/haptics";
 
 import { SmartInstruction } from "@/components/recipe/smart-instruction";
 import ImageLightbox from "@/components/shared/image-lightbox";
@@ -19,6 +20,14 @@ export default function StepsList() {
   const [lightboxInitialIndex, setLightboxInitialIndex] = useState(0);
 
   const toggle = (i: number) => {
+    // Call haptics synchronously in the event handler's call stack so browsers treat it as a user gesture (required by Chrome).
+    try {
+      const adding = !done.has(i);
+      triggerHaptic(adding ? "success" : "selection");
+    } catch {
+      // ignore
+    }
+
     setDone((prev) => {
       const next = new Set(prev);
 

--- a/packages/shared/src/lib/haptics.ts
+++ b/packages/shared/src/lib/haptics.ts
@@ -1,0 +1,68 @@
+export type HapticType = "selection" | "success";
+
+export function triggerHaptic(type: HapticType = "selection") {
+  if (typeof window === "undefined" || typeof navigator === "undefined") return;
+
+  try {
+    // Respect user motion preferences
+    if (window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+      return;
+    }
+
+    const nav = navigator as any;
+    if (typeof nav?.vibrate === "function") {
+      const patterns: Record<HapticType, number | number[]> = {
+        selection: 20,
+        success: 30,
+      };
+
+      try {
+        nav.vibrate(patterns[type]);
+      } catch {
+        // ignore
+      }
+
+      return;
+    }
+
+    // iOS/WebKit best-effort fallback
+    try {
+      const ua = navigator.userAgent || "";
+      const isIosWebKit = /AppleWebKit/.test(ua) && /iP(hone|ad|od)/.test(ua) && !/CriOS|FxiOS|OPiOS/.test(ua);
+      if (isIosWebKit && document?.body) {
+        const container = document.createElement("div");
+        container.setAttribute("aria-hidden", "true");
+        container.style.position = "fixed";
+        container.style.left = "-9999px";
+        container.style.top = "-9999px";
+        container.style.opacity = "0";
+
+        const id = `h-${Math.random().toString(36).slice(2)}`;
+        const input = document.createElement("input");
+        input.type = "checkbox";
+        input.id = id;
+        input.tabIndex = -1;
+
+        const label = document.createElement("label");
+        label.htmlFor = id;
+        label.tabIndex = -1;
+
+        container.appendChild(input);
+        container.appendChild(label);
+        document.body.appendChild(container);
+
+        try {
+          label.click();
+        } catch {
+          /* ignore */
+        }
+
+        setTimeout(() => container.remove(), 200);
+      }
+    } catch {
+      /* ignore */
+    }
+  } catch {
+    // ignore
+  }
+}


### PR DESCRIPTION
Add vibration feedback on mobile devices when checking off ingredients or recipe steps.
* Tested on android
* iOS does not provide a vibrate api, so it uses a fallback I found online: https://progressier.com/pwa-capabilities/vibration-api
Can't test it on my iPhone right now, but even if it doesn't work on iPhone, it's not breaking.