### PR TITLE
fix/feat: uom pluralization

### DIFF
--- a/apps/web/app/(app)/recipes/[id]/components/ingredient-list.tsx
+++ b/apps/web/app/(app)/recipes/[id]/components/ingredient-list.tsx
@@ -16,7 +16,7 @@ export default function IngredientsList() {
   const { adjustedIngredients, recipe } = useRecipeContextRequired();
   const [checked, setChecked] = useState<Set<number>>(() => new Set());
   const { mode } = useAmountDisplayPreference();
-  const { formatAmountUnit } = useUnitFormatter();
+  const { formatUnitOnly } = useUnitFormatter();
 
   // Use adjustedIngredients directly, fall back to recipe ingredients only if empty
   const display = adjustedIngredients?.length > 0 ? adjustedIngredients : recipe.recipeIngredients;
@@ -61,7 +61,7 @@ export default function IngredientsList() {
 
           const amount = formatAmount(it.amount, mode);
           // Format unit with locale-aware display
-          const unit = it.unit ? formatAmountUnit(null, it.unit) : "";
+          const unit = it.unit ? formatUnitOnly(it.unit, it.amount) : "";
           const isChecked = checked.has(idx);
 
           return (

--- a/apps/web/hooks/use-unit-formatter.ts
+++ b/apps/web/hooks/use-unit-formatter.ts
@@ -13,6 +13,15 @@ export function useUnitFormatter() {
   const locale = useLocale();
   const { units } = useUnitsQuery();
 
+  const formatUnitOnly = (
+    unit: string | null | undefined,
+    amount?: number | null | undefined
+  ): string => {
+    if (!unit) return "";
+
+    return formatUnit(unit, locale, units, amount);
+  };
+
   /**
    * Format amount and unit for display (e.g., "500 g" or "2 tbsp")
    * Handles spacing automatically (short units get no space: "500g", longer ones do: "2 tbsp")
@@ -31,7 +40,7 @@ export function useUnitFormatter() {
     }
 
     // Format the unit
-    const localizedUnit = formatUnit(unit, locale, units);
+    const localizedUnit = formatUnit(unit, locale, units, amount);
 
     // If no amount, return just the unit
     if (!amount && amount !== 0) {
@@ -49,6 +58,7 @@ export function useUnitFormatter() {
 
   return {
     formatAmountUnit,
+    formatUnitOnly,
     locale,
     units,
   };

--- a/packages/shared/__tests__/lib/unit-localization.test.ts
+++ b/packages/shared/__tests__/lib/unit-localization.test.ts
@@ -106,6 +106,23 @@ describe("Unit Localization", () => {
         expect(formatUnit("unknownUnit", "de", unitsConfig)).toBe("unknownUnit");
       });
     });
+
+    describe("Quantity-based form selection", () => {
+      it("uses plural when quantity is greater than 1", () => {
+        expect(formatUnit("gram", "en", unitsConfig, 2)).toBe("grams");
+        expect(formatUnit("tablespoon", "en", unitsConfig, 2)).toBe("tablespoons");
+      });
+
+      it("uses short/singular when quantity is 1 or lower", () => {
+        expect(formatUnit("gram", "en", unitsConfig, 1)).toBe("g");
+        expect(formatUnit("gram", "en", unitsConfig, 0.5)).toBe("g");
+      });
+
+      it("uses short/singular when quantity is missing", () => {
+        expect(formatUnit("gram", "en", unitsConfig, null)).toBe("g");
+        expect(formatUnit("gram", "en", unitsConfig)).toBe("g");
+      });
+    });
   });
 
   describe("flattenForLibrary - prepare config for parser", () => {

--- a/packages/shared/src/lib/unit-localization.ts
+++ b/packages/shared/src/lib/unit-localization.ts
@@ -1,5 +1,7 @@
 import type { FlatUnitsMap, UnitsMap } from "@norish/config/zod/server-config";
 
+import { selectUnitForm } from "@/lib/unit-form-selector";
+
 /**
  * Flatten locale-aware units config to flat format for parse-ingredient library.
  * Uses the first locale's short and plural forms so the parser can recognize both.
@@ -87,25 +89,23 @@ export function normalizeUnit(unit: string, config: UnitsMap): string {
 
 /**
  * Format a unit for display based on user's locale.
- * Always uses the short/abbreviated form for consistency (e.g., "g", "tbsp", "tsp").
+ * Uses short form by default, and plural form when quantity > 1.
  *
  * @param unitId - The canonical unit ID (e.g., "gram", "tablespoon", "dash")
  * @param userLocale - User's locale (e.g., "en", "de-formal", "nl")
  * @param config - The locale-aware units configuration
+ * @param quantity - Optional quantity used to decide singular/plural form
  * @returns The localized unit name
  *
  * @example
  * formatUnit("gram", "en", config) => "g"
  * formatUnit("gram", "de", config) => "g"
+ * formatUnit("gram", "en", config, 2) => "grams"
  */
-export function formatUnit(unitId: string, userLocale: string, config: UnitsMap): string {
-  const unitDef = config[unitId];
-
-  if (!unitDef) return unitId; // Unknown unit, return as-is
-
-  // Always use short form for consistent abbreviated display
-  const forms = unitDef.short;
-
+function getLocalizedUnitName(
+  forms: Array<{ locale: string; name: string }>,
+  userLocale: string
+): string | null {
   // Try exact match first (e.g., "de-formal")
   const exactMatch = forms.find((f) => f.locale === userLocale);
 
@@ -128,5 +128,26 @@ export function formatUnit(unitId: string, userLocale: string, config: UnitsMap)
   if (en) return en.name;
 
   // Last resort: first available
-  return forms[0]?.name || unitId;
+  return forms[0]?.name ?? null;
+}
+
+export function formatUnit(
+  unitId: string,
+  userLocale: string,
+  config: UnitsMap,
+  quantity?: number | null
+): string {
+  const unitDef = config[unitId];
+
+  if (!unitDef) return unitId; // Unknown unit, return as-is
+
+  const singular = getLocalizedUnitName(unitDef.short, userLocale);
+  const plural = getLocalizedUnitName(unitDef.plural, userLocale);
+
+  return (
+    selectUnitForm(quantity, {
+      singular,
+      plural,
+    }) ?? unitId
+  );
 }

--- a/packages/shared/src/lib/unit-localization.ts
+++ b/packages/shared/src/lib/unit-localization.ts
@@ -1,6 +1,6 @@
 import type { FlatUnitsMap, UnitsMap } from "@norish/config/zod/server-config";
 
-import { selectUnitForm } from "@/lib/unit-form-selector";
+import { selectUnitForm } from "./unit-form-selector";
 
 /**
  * Flatten locale-aware units config to flat format for parse-ingredient library.


### PR DESCRIPTION
## Description

Right now only the singular form of the uom is displayed always. Which causes grammatically incorrect ingredient lists that can be weird to read, like `200 gram of sugar` instead of `200 grams of sugar`.

This PR fixes that by determining whether to use singular or plural based on the quantity:
* <=1 = singular
* \>1 = plural

It also updates when the quantity changes due to the user adjusting the portion count.

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] Other (please describe):

## Checklist

<!-- Mark the appropriate options with an "x" -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published