### PR TITLE
fix: adjust logo alignment in AuthCard

### DIFF
--- a/apps/web/app/(auth)/components/auth-card.tsx
+++ b/apps/web/app/(auth)/components/auth-card.tsx
@@ -26,9 +26,9 @@ export function AuthCard({ title, subtitle, children, footer }: AuthCardProps) {
 
           {/* Header */}
           <div className="flex flex-col items-center gap-2 text-center">
-            <h1 className="flex items-center justify-center gap-2 text-2xl font-bold">
+            <h1 className="flex items-baseline justify-center gap-2 text-2xl font-bold">
               <span>{title}</span>
-              <BrandLogo priority className="-mt-[2px]" height={34} width={120} />
+              <BrandLogo priority className="shrink-0" height={34} width={120} />
             </h1>
             <p className="text-small text-default-500">{subtitle}</p>
           </div>


### PR DESCRIPTION
## Description

Just a really small fix: It's been bothering me for a while that the logo on the Auth page isn't aligned correctly.

## Related Issue(s)

None

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] Other (please describe):

## Screenshots (if applicable)
* Before:
<img width="480" height="450" alt="vivaldi_Qx728MvVg7" src="https://github.com/user-attachments/assets/1a875614-ce0c-471f-b4cf-427137387173" />

* After:
<img width="470" height="452" alt="vivaldi_PSQJZjAjUk" src="https://github.com/user-attachments/assets/dc225ea8-5f6e-45d8-95c7-087780d5abf1" />


## Checklist

<!-- Mark the appropriate options with an "x" -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published