### PR TITLE
feat: replace normal input with inputOTP

### DIFF
--- a/apps/web/app/(app)/settings/household/components/no-household-view.tsx
+++ b/apps/web/app/(app)/settings/household/components/no-household-view.tsx
@@ -1,8 +1,16 @@
 "use client";
 
-import { FormEvent, useState } from "react";
+import { useState, FormEvent } from "react";
+import {
+  Button,
+  Card,
+  CardBody,
+  CardHeader,
+  Input,
+  InputOtp,
+  REGEXP_ONLY_DIGITS,
+} from "@heroui/react";
 import { HomeIcon, UserGroupIcon } from "@heroicons/react/24/outline";
-import { Button, Card, CardBody, CardHeader, Input } from "@heroui/react";
 import { useTranslations } from "next-intl";
 
 import { useHouseholdSettingsContext } from "../context";
@@ -74,10 +82,12 @@ export default function NoHouseholdView() {
           <CardBody>
             <form className="flex flex-col gap-4" onSubmit={handleJoinHousehold}>
               <p className="text-default-600 text-base">{t("join.description")}</p>
-              <Input
+              <InputOtp
                 isRequired
+                allowedKeys={REGEXP_ONLY_DIGITS}
+                classNames={{ segmentWrapper: "justify-start" }}
                 label={t("join.codeLabel")}
-                maxLength={8}
+                length={6}
                 placeholder={t("join.codePlaceholder")}
                 value={joinCode}
                 onValueChange={setJoinCode}


### PR DESCRIPTION
## Description

Very low prio I guess, but:
Since the household join code is kind of like an OTP, I felt like the HeroUI InputOTP component is a better fit than the normal Input field.

## Related Issue(s)

<!-- Link to the related issue(s) this PR addresses -->

Fixes #

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] Other (please describe):

## Screenshots (if applicable)
<img width="594" height="293" alt="brave_kGf2hMy0Gd" src="https://github.com/user-attachments/assets/50e81daa-cb60-40cf-a839-fde9aecd66db" />

<img width="587" height="280" alt="brave_xw7PDRYzfY" src="https://github.com/user-attachments/assets/7f2e3706-3ba1-4261-b15b-5d340d0b6e2d" />

## Checklist

<!-- Mark the appropriate options with an "x" -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published