### PR TITLE
fix: browser friendly video codec

### DIFF
--- a/packages/api/__tests__/server/downloader-convert-to-mp4.test.ts
+++ b/packages/api/__tests__/server/downloader-convert-to-mp4.test.ts
@@ -86,7 +86,7 @@ vi.mock("child_process", () => ({
   spawn: mockState.spawnMock,
 }));
 
-import { convertToMp4 } from "@/server/downloader";
+import { convertToMp4 } from "@norish/api/downloader";
 
 describe("convertToMp4", () => {
   const normalizePath = (value: string) => value.replaceAll("\\", "/");

--- a/packages/api/__tests__/server/downloader-convert-to-mp4.test.ts
+++ b/packages/api/__tests__/server/downloader-convert-to-mp4.test.ts
@@ -1,0 +1,201 @@
+// @vitest-environment node
+import { EventEmitter } from "events";
+import path from "node:path";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockState = vi.hoisted(() => ({
+  fsStatMock: vi.fn(),
+  fsUnlinkMock: vi.fn(),
+  fsAccessMock: vi.fn(),
+  spawnCalls: [] as Array<{ cmd: string; args: string[] }>,
+  spawnMock: vi.fn(),
+}));
+
+vi.mock("@/config/env-config-server", () => ({
+  SERVER_CONFIG: {
+    UPLOADS_DIR: "/test/uploads",
+    MAX_AVATAR_FILE_SIZE: 5 * 1024 * 1024,
+    MAX_IMAGE_FILE_SIZE: 10 * 1024 * 1024,
+    MAX_VIDEO_FILE_SIZE: 100 * 1024 * 1024,
+  },
+}));
+
+vi.mock("@/config/server-config-loader", () => ({
+  getMaxVideoFileSize: vi.fn().mockResolvedValue(100 * 1024 * 1024),
+}));
+
+vi.mock("@/server/logger", () => ({
+  serverLogger: {
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("fs/promises", () => ({
+  default: {
+    stat: mockState.fsStatMock,
+    unlink: mockState.fsUnlinkMock,
+    access: mockState.fsAccessMock,
+    mkdir: vi.fn(),
+    writeFile: vi.fn(),
+    copyFile: vi.fn(),
+    rm: vi.fn(),
+    readdir: vi.fn(),
+  },
+}));
+
+mockState.spawnMock.mockImplementation((cmd: string, args: string[]) => {
+  mockState.spawnCalls.push({ cmd, args });
+
+  const proc = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+  };
+
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+
+  if (args.includes("-print_format")) {
+    setImmediate(() => {
+      proc.stdout.emit(
+        "data",
+        Buffer.from(
+          JSON.stringify({
+            streams: [
+              { codec_type: "video", codec_name: "h264" },
+              { codec_type: "audio", codec_name: "aac" },
+            ],
+          })
+        )
+      );
+      proc.emit("close", 0);
+    });
+  } else {
+    setImmediate(() => {
+      proc.emit("close", 0);
+    });
+  }
+
+  return proc;
+});
+
+vi.mock("child_process", () => ({
+  spawn: mockState.spawnMock,
+}));
+
+import { convertToMp4 } from "@/server/downloader";
+
+describe("convertToMp4", () => {
+  const normalizePath = (value: string) => value.replaceAll("\\", "/");
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockState.spawnCalls.length = 0;
+    mockState.fsStatMock.mockResolvedValue({ size: 1234 });
+    mockState.fsUnlinkMock.mockResolvedValue(undefined);
+    mockState.fsAccessMock.mockRejectedValue(new Error("not found"));
+  });
+
+  it("keeps browser-compatible mp4 unchanged", async () => {
+    const result = await convertToMp4("/tmp/input.mp4", "/usr/bin/ffmpeg");
+
+    expect(result).toEqual({
+      filePath: "/tmp/input.mp4",
+      converted: false,
+      method: "none",
+    });
+    expect(mockState.spawnCalls).toHaveLength(1);
+    expect(mockState.spawnCalls[0].cmd).toContain("ffprobe");
+    expect(mockState.fsStatMock).not.toHaveBeenCalled();
+  });
+
+  it("remuxes non-mp4 with compatible codecs", async () => {
+    const result = await convertToMp4("/tmp/input.mkv", "/usr/bin/ffmpeg");
+
+    expect(result).toEqual({
+      filePath: path.join("/tmp", "input.mp4"),
+      converted: true,
+      method: "remux",
+    });
+    expect(mockState.spawnCalls).toHaveLength(2);
+    expect(mockState.spawnCalls[0].cmd).toContain("ffprobe");
+    expect(mockState.spawnCalls[1].cmd).toBe("/usr/bin/ffmpeg");
+    expect(mockState.spawnCalls[1].args).toContain("-c");
+    expect(mockState.spawnCalls[1].args).toContain("copy");
+    expect(normalizePath(mockState.fsUnlinkMock.mock.calls[0][0])).toBe("/tmp/input.mkv");
+  });
+
+  it("transcodes mp4 when codecs are not browser-compatible", async () => {
+    mockState.spawnMock.mockImplementationOnce((cmd: string, args: string[]) => {
+      mockState.spawnCalls.push({ cmd, args });
+      const proc = new EventEmitter() as EventEmitter & {
+        stdout: EventEmitter;
+        stderr: EventEmitter;
+      };
+      proc.stdout = new EventEmitter();
+      proc.stderr = new EventEmitter();
+      setImmediate(() => {
+        proc.stdout.emit(
+          "data",
+          Buffer.from(
+            JSON.stringify({
+              streams: [
+                { codec_type: "video", codec_name: "hevc" },
+                { codec_type: "audio", codec_name: "aac" },
+              ],
+            })
+          )
+        );
+        proc.emit("close", 0);
+      });
+
+      return proc;
+    });
+
+    const result = await convertToMp4("/tmp/input.mp4", "/usr/bin/ffmpeg");
+
+    expect(result).toEqual({
+      filePath: path.join("/tmp", "input-normalized.mp4"),
+      converted: true,
+      method: "transcode",
+    });
+    expect(mockState.spawnCalls).toHaveLength(2);
+    expect(mockState.spawnCalls[0].cmd).toContain("ffprobe");
+    expect(mockState.spawnCalls[1].cmd).toBe("/usr/bin/ffmpeg");
+    expect(mockState.spawnCalls[1].args).toContain("libx264");
+    expect(mockState.spawnCalls[1].args).toContain("aac");
+    expect(normalizePath(mockState.fsUnlinkMock.mock.calls[0][0])).toBe("/tmp/input.mp4");
+  });
+
+  it("transcodes when ffprobe fails to return codec info", async () => {
+    mockState.spawnMock.mockImplementationOnce((cmd: string, args: string[]) => {
+      mockState.spawnCalls.push({ cmd, args });
+      const proc = new EventEmitter() as EventEmitter & {
+        stdout: EventEmitter;
+        stderr: EventEmitter;
+      };
+      proc.stdout = new EventEmitter();
+      proc.stderr = new EventEmitter();
+      setImmediate(() => {
+        proc.emit("close", 1);
+      });
+
+      return proc;
+    });
+
+    const result = await convertToMp4("/tmp/input.webm", "/usr/bin/ffmpeg");
+
+    expect(result).toEqual({
+      filePath: path.join("/tmp", "input.mp4"),
+      converted: true,
+      method: "transcode",
+    });
+    expect(mockState.spawnCalls).toHaveLength(2);
+    expect(mockState.spawnCalls[0].cmd).toContain("ffprobe");
+    expect(mockState.spawnCalls[1].cmd).toBe("/usr/bin/ffmpeg");
+    expect(mockState.spawnCalls[1].args).toContain("libx264");
+  });
+});

--- a/packages/api/__tests__/server/downloader-video-codec.test.ts
+++ b/packages/api/__tests__/server/downloader-video-codec.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/config/env-config-server", () => ({
+  SERVER_CONFIG: {
+    UPLOADS_DIR: "/test/uploads",
+    MAX_AVATAR_FILE_SIZE: 5 * 1024 * 1024,
+    MAX_IMAGE_FILE_SIZE: 10 * 1024 * 1024,
+    MAX_VIDEO_FILE_SIZE: 100 * 1024 * 1024,
+  },
+}));
+
+vi.mock("@/config/server-config-loader", () => ({
+  getMaxVideoFileSize: vi.fn().mockResolvedValue(100 * 1024 * 1024),
+}));
+
+vi.mock("@/server/logger", () => ({
+  serverLogger: {
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("sharp", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("heic-convert", () => ({
+  default: vi.fn(),
+}));
+
+import { isWebPlayableMp4CodecPair } from "@/server/downloader";
+
+describe("isWebPlayableMp4CodecPair", () => {
+  it("accepts H.264 video with AAC audio", () => {
+    expect(isWebPlayableMp4CodecPair("h264", "aac")).toBe(true);
+  });
+
+  it("accepts avc1 video with mp4a audio profile", () => {
+    expect(isWebPlayableMp4CodecPair("avc1", "mp4a.40.2")).toBe(true);
+  });
+
+  it("accepts silent H.264 video", () => {
+    expect(isWebPlayableMp4CodecPair("h264", null)).toBe(true);
+  });
+
+  it("rejects HEVC video", () => {
+    expect(isWebPlayableMp4CodecPair("hevc", "aac")).toBe(false);
+  });
+
+  it("rejects unsupported audio codec in MP4", () => {
+    expect(isWebPlayableMp4CodecPair("h264", "opus")).toBe(false);
+  });
+
+  it("rejects missing video codec", () => {
+    expect(isWebPlayableMp4CodecPair(null, "aac")).toBe(false);
+  });
+});

--- a/packages/api/__tests__/server/downloader-video-codec.test.ts
+++ b/packages/api/__tests__/server/downloader-video-codec.test.ts
@@ -31,7 +31,7 @@ vi.mock("heic-convert", () => ({
   default: vi.fn(),
 }));
 
-import { isWebPlayableMp4CodecPair } from "@/server/downloader";
+import { isWebPlayableMp4CodecPair } from "@norish/api/downloader";
 
 describe("isWebPlayableMp4CodecPair", () => {
   it("accepts H.264 video with AAC audio", () => {

--- a/packages/api/__tests__/server/video/yt-dlp-format-selector.test.ts
+++ b/packages/api/__tests__/server/video/yt-dlp-format-selector.test.ts
@@ -6,7 +6,17 @@ import { DOWNLOAD_VIDEO_FORMAT_SELECTOR } from "@norish/api/video/yt-dlp";
 describe("download video format selector", () => {
   it("prioritizes progressive mp4 before DASH-only variants", () => {
     expect(DOWNLOAD_VIDEO_FORMAT_SELECTOR).toBe(
-      "best[ext=mp4]/bestvideo[vcodec^=avc1][ext=mp4]+bestaudio[ext=m4a]/bestvideo[ext=mp4]+bestaudio[ext=m4a]/best"
+      "best[vcodec^=avc1][ext=mp4]/bestvideo[vcodec^=avc1][ext=mp4]+bestaudio[ext=m4a]/bestvideo[vcodec^=avc1]+bestaudio[acodec^=mp4a]/best[ext=mp4]/best"
     );
+  });
+
+  it("keeps compatibility-first fallback ordering", () => {
+    const parts = DOWNLOAD_VIDEO_FORMAT_SELECTOR.split("/");
+
+    expect(parts[0]).toBe("best[vcodec^=avc1][ext=mp4]");
+    expect(parts[1]).toBe("bestvideo[vcodec^=avc1][ext=mp4]+bestaudio[ext=m4a]");
+    expect(parts[2]).toBe("bestvideo[vcodec^=avc1]+bestaudio[acodec^=mp4a]");
+    expect(parts[3]).toBe("best[ext=mp4]");
+    expect(parts[4]).toBe("best");
   });
 });

--- a/packages/api/src/downloader.ts
+++ b/packages/api/src/downloader.ts
@@ -731,7 +731,10 @@ async function resolveFfprobePath(ffmpegPath: string): Promise<string> {
   return ffprobeBinary;
 }
 
-async function probeVideoCodecs(inputPath: string, ffmpegPath: string): Promise<VideoCodecInfo | null> {
+async function probeVideoCodecs(
+  inputPath: string,
+  ffmpegPath: string
+): Promise<VideoCodecInfo | null> {
   const ffprobePath = await resolveFfprobePath(ffmpegPath);
 
   return new Promise((resolve) => {

--- a/packages/api/src/downloader.ts
+++ b/packages/api/src/downloader.ts
@@ -681,9 +681,122 @@ export interface ConvertToMp4Result {
   method: "none" | "remux" | "transcode" | "original";
 }
 
+interface VideoCodecInfo {
+  videoCodec: string | null;
+  audioCodec: string | null;
+}
+
+function normalizeCodecName(codec: string | null | undefined): string | null {
+  if (!codec) return null;
+
+  return codec.trim().toLowerCase();
+}
+
+/**
+ * Browser-safe MP4 profile:
+ * Video: H.264/AVC
+ * Audio: AAC/MP3 (or no audio)
+ */
+export function isWebPlayableMp4CodecPair(
+  videoCodec: string | null | undefined,
+  audioCodec: string | null | undefined
+): boolean {
+  const normalizedVideo = normalizeCodecName(videoCodec);
+
+  if (!normalizedVideo) return false;
+
+  const isVideoCompatible =
+    normalizedVideo === "h264" || normalizedVideo === "avc" || normalizedVideo.startsWith("avc1");
+
+  if (!isVideoCompatible) return false;
+
+  const normalizedAudio = normalizeCodecName(audioCodec);
+
+  if (!normalizedAudio) return true;
+
+  return (
+    normalizedAudio === "aac" || normalizedAudio === "mp3" || normalizedAudio.startsWith("mp4a")
+  );
+}
+
+async function resolveFfprobePath(ffmpegPath: string): Promise<string> {
+  const ffprobeBinary = process.platform === "win32" ? "ffprobe.exe" : "ffprobe";
+  const siblingPath = path.join(path.dirname(ffmpegPath), ffprobeBinary);
+
+  if (await fileExists(siblingPath)) {
+    return siblingPath;
+  }
+
+  // Fallback to PATH lookup.
+  return ffprobeBinary;
+}
+
+async function probeVideoCodecs(inputPath: string, ffmpegPath: string): Promise<VideoCodecInfo | null> {
+  const ffprobePath = await resolveFfprobePath(ffmpegPath);
+
+  return new Promise((resolve) => {
+    const proc = spawn(
+      ffprobePath,
+      [
+        "-v",
+        "error",
+        "-print_format",
+        "json",
+        "-show_entries",
+        "stream=codec_type,codec_name",
+        "-i",
+        inputPath,
+      ],
+      { stdio: ["ignore", "pipe", "pipe"] }
+    );
+
+    let stdout = "";
+    let stderr = "";
+
+    proc.stdout?.on("data", (data) => {
+      stdout += data.toString();
+    });
+
+    proc.stderr?.on("data", (data) => {
+      stderr += data.toString();
+    });
+
+    proc.on("error", (err) => {
+      log.debug({ err, ffprobePath }, "Failed to start ffprobe");
+      resolve(null);
+    });
+
+    proc.on("close", (code) => {
+      if (code !== 0) {
+        log.debug({ ffprobePath, code, stderr: stderr.slice(-500) }, "ffprobe failed");
+        resolve(null);
+
+        return;
+      }
+
+      try {
+        const parsed = JSON.parse(stdout) as {
+          streams?: Array<{ codec_type?: string; codec_name?: string }>;
+        };
+        const streams = parsed.streams ?? [];
+        const videoCodec = streams.find((s) => s.codec_type === "video")?.codec_name ?? null;
+        const audioCodec = streams.find((s) => s.codec_type === "audio")?.codec_name ?? null;
+
+        resolve({ videoCodec, audioCodec });
+      } catch (err) {
+        log.debug({ err, ffprobePath }, "Failed to parse ffprobe output");
+        resolve(null);
+      }
+    });
+  });
+}
+
 /**
  * Convert video to MP4 format if needed.
- * Strategy: Try remux first (fast, lossless), fallback to transcode, keep original if both fail.
+ * Strategy:
+ * Keep only browser-compatible MP4 (H.264 + AAC/MP3)
+ * Remux non-MP4 only when codecs are already compatible
+ * Transcode everything else to H.264/AAC
  */
 export async function convertToMp4(
   inputPath: string,
@@ -691,51 +804,67 @@ export async function convertToMp4(
 ): Promise<ConvertToMp4Result> {
   const ext = path.extname(inputPath).toLowerCase();
 
-  // Already MP4 - no conversion needed
-  if (ext === ".mp4") {
-    log.debug({ inputPath }, "Video is already MP4, no conversion needed");
-
-    return { filePath: inputPath, converted: false, method: "none" };
-  }
-
   if (!ffmpegPath) {
     log.warn({ inputPath }, "ffmpeg not available, keeping original format");
 
     return { filePath: inputPath, converted: false, method: "original" };
   }
 
+  const codecInfo = await probeVideoCodecs(inputPath, ffmpegPath);
+  const browserCompatibleMp4 = isWebPlayableMp4CodecPair(
+    codecInfo?.videoCodec,
+    codecInfo?.audioCodec
+  );
+
+  // MP4 can be kept only when codecs are browser-friendly (e.g. H.264 + AAC).
+  if (ext === ".mp4" && browserCompatibleMp4) {
+    log.debug(
+      {
+        inputPath,
+        videoCodec: codecInfo?.videoCodec ?? null,
+        audioCodec: codecInfo?.audioCodec ?? null,
+      },
+      "Video is already browser-compatible MP4, no conversion needed"
+    );
+
+    return { filePath: inputPath, converted: false, method: "none" };
+  }
+
   const dir = path.dirname(inputPath);
   const baseName = path.basename(inputPath, ext);
-  const outputPath = path.join(dir, `${baseName}.mp4`);
+  const outputBaseName = ext === ".mp4" ? `${baseName}-normalized` : baseName;
+  const outputPath = path.join(dir, `${outputBaseName}.mp4`);
 
-  // Try remux first (fast, lossless copy of streams into MP4 container)
-  try {
-    log.debug({ inputPath, outputPath }, "Attempting video remux to MP4");
+  // Try remux first only for non-MP4 sources that already use browser-compatible codecs.
+  if (ext !== ".mp4" && browserCompatibleMp4) {
+    try {
+      log.debug({ inputPath, outputPath }, "Attempting video remux to MP4");
 
-    await runFfmpeg(ffmpegPath, [
-      "-i",
-      inputPath,
-      "-c",
-      "copy", // Copy streams without re-encoding
-      "-movflags",
-      "+faststart", // Optimize for web streaming
-      outputPath,
-    ]);
+      await runFfmpeg(ffmpegPath, [
+        "-i",
+        inputPath,
+        "-c",
+        "copy", // Copy streams without re-encoding
+        "-movflags",
+        "+faststart", // Optimize for web streaming
+        outputPath,
+      ]);
 
-    // Verify output exists and has content
-    const stats = await fs.stat(outputPath);
+      // Verify output exists and has content
+      const stats = await fs.stat(outputPath);
 
-    if (stats.size > 0) {
-      // Remove original file
-      await fs.unlink(inputPath).catch(() => {});
-      log.info({ inputPath, outputPath, size: stats.size }, "Video remuxed to MP4 successfully");
+      if (stats.size > 0) {
+        // Remove original file
+        await fs.unlink(inputPath).catch(() => {});
+        log.info({ inputPath, outputPath, size: stats.size }, "Video remuxed to MP4 successfully");
 
-      return { filePath: outputPath, converted: true, method: "remux" };
+        return { filePath: outputPath, converted: true, method: "remux" };
+      }
+    } catch (remuxErr) {
+      log.debug({ err: remuxErr }, "Remux failed, trying transcode");
+      // Remove failed output if it exists
+      await fs.unlink(outputPath).catch(() => {});
     }
-  } catch (remuxErr) {
-    log.debug({ err: remuxErr }, "Remux failed, trying transcode");
-    // Remove failed output if it exists
-    await fs.unlink(outputPath).catch(() => {});
   }
 
   // Fallback to transcode (slower, but handles incompatible codecs)

--- a/packages/api/src/video/yt-dlp.ts
+++ b/packages/api/src/video/yt-dlp.ts
@@ -104,7 +104,7 @@ function getFfmpegPath(): string | null {
 const ytDlpFilename = process.platform === "win32" ? "yt-dlp.exe" : "yt-dlp";
 
 export const DOWNLOAD_VIDEO_FORMAT_SELECTOR =
-  "best[ext=mp4]/bestvideo[vcodec^=avc1][ext=mp4]+bestaudio[ext=m4a]/bestvideo[ext=mp4]+bestaudio[ext=m4a]/best";
+  "best[vcodec^=avc1][ext=mp4]/bestvideo[vcodec^=avc1][ext=mp4]+bestaudio[ext=m4a]/bestvideo[vcodec^=avc1]+bestaudio[acodec^=mp4a]/best[ext=mp4]/best";
 
 // In production (Docker), binary is pre-downloaded during build to /app/bin
 // In development, download to the configured runtime bin directory on first use


### PR DESCRIPTION
## Description

I was playing around with the video import and noticed that on imported TikTok videos, it would just play audio with a black video in the browser. The problem was that the parser only checked whether the file was .mp4, not whether the actual video/audio codecs were browser friendly.

This fix now prioritizes browser-compatible formats earlier in yt-dlp, and makes conversion codec-aware instead of extension-only. We now keep MP4s only when they’re actually web-playable (H.264 + AAC/MP3), remux compatible non-MP4 inputs, and transcode everything else to a safe MP4

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] Other (please describe):

## Checklist

<!-- Mark the appropriate options with an "x" -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published