### PR TITLE
fix/feat: rise favorite button to make space for video controls on mobile

### DIFF
--- a/apps/web/app/(app)/recipes/[id]/recipe-page-mobile.tsx
+++ b/apps/web/app/(app)/recipes/[id]/recipe-page-mobile.tsx
@@ -9,6 +9,7 @@ import {
 } from "@heroicons/react/16/solid";
 import { Card, CardBody, Chip, Divider, Link } from "@heroui/react";
 import { useTranslations } from "next-intl";
+import { useEffect, useMemo, useState } from "react";
 import {
   formatMinutesHM,
   isAllergenTag,
@@ -65,6 +66,23 @@ export default function RecipePageMobile() {
 
   // Build media items for MediaCarousel (videos + images)
   const mediaItems = buildMediaItems(recipe);
+  const initialActiveMediaType = useMemo(() => {
+    if (!mediaItems.length) return "image";
+    const sortedItems = [...mediaItems].sort((a, b) => {
+      if (a.order !== b.order) return a.order - b.order;
+      if (a.type !== b.type) return a.type === "video" ? -1 : 1;
+
+      return 0;
+    });
+
+    return sortedItems[0]?.type ?? "image";
+  }, [mediaItems]);
+  const [activeMediaType, setActiveMediaType] = useState<"image" | "video">(initialActiveMediaType);
+  const [isVideoControlsVisible, setIsVideoControlsVisible] = useState(false);
+
+  useEffect(() => {
+    setActiveMediaType(initialActiveMediaType);
+  }, [initialActiveMediaType]);
 
   return (
     <div
@@ -87,6 +105,13 @@ export default function RecipePageMobile() {
             aspectRatio="4/3"
             className="h-full w-full"
             items={mediaItems}
+            onActiveItemChange={(item) => {
+              setActiveMediaType(item.type);
+              if (item.type !== "video") {
+                setIsVideoControlsVisible(false);
+              }
+            }}
+            onActiveVideoControlsVisibilityChange={setIsVideoControlsVisible}
             rounded={false}
           />
         </DoubleTapContainer>
@@ -107,7 +132,9 @@ export default function RecipePageMobile() {
 
         {/* Heart button - bottom right */}
         {showFavorites && (
-          <div className="absolute right-4 bottom-8 z-50">
+          <div
+            className={`absolute right-4 z-50 transition-[bottom] duration-200 ${activeMediaType === "video" && isVideoControlsVisible ? "bottom-18" : "bottom-8"}`}
+          >
             <HeartButton
               showBackground
               isFavorite={isFavorite}

--- a/apps/web/components/shared/media-carousel.tsx
+++ b/apps/web/components/shared/media-carousel.tsx
@@ -77,6 +77,8 @@ export function buildMediaItems(recipe: RecipeMedia): MediaItem[] {
 export interface MediaCarouselProps {
   items: MediaItem[];
   onImageClick?: (index: number) => void;
+  onActiveItemChange?: (item: MediaItem, index: number) => void;
+  onActiveVideoControlsVisibilityChange?: (visible: boolean) => void;
   className?: string;
   aspectRatio?: "video" | "square" | "4/3";
   rounded?: boolean;
@@ -85,6 +87,8 @@ export interface MediaCarouselProps {
 export default function MediaCarousel({
   items,
   onImageClick,
+  onActiveItemChange,
+  onActiveVideoControlsVisibilityChange,
   className = "",
   aspectRatio = "video",
   rounded = true,
@@ -133,6 +137,21 @@ export default function MediaCarousel({
       clearPendingLightboxOpen();
     };
   }, [clearPendingLightboxOpen]);
+
+  useEffect(() => {
+    if (!sortedItems.length) return;
+    const safeIndex = Math.min(currentIndex, sortedItems.length - 1);
+    const activeItem = sortedItems[safeIndex];
+
+    if (!activeItem) return;
+    onActiveItemChange?.(activeItem, safeIndex);
+  }, [currentIndex, onActiveItemChange, sortedItems]);
+
+  useEffect(() => {
+    if (!sortedItems.length) return;
+    if (currentIndex <= sortedItems.length - 1) return;
+    setCurrentIndex(sortedItems.length - 1);
+  }, [currentIndex, sortedItems.length]);
 
   const handleNext = useCallback(() => {
     setDirection(1);
@@ -246,6 +265,7 @@ export default function MediaCarousel({
             <VideoPlayer
               className="h-full w-full"
               duration={item.duration}
+              onControlsVisibilityChange={onActiveVideoControlsVisibilityChange}
               poster={item.thumbnail || undefined}
               src={item.src}
             />
@@ -312,6 +332,7 @@ export default function MediaCarousel({
               <VideoPlayer
                 className="h-full w-full"
                 duration={sortedItems[currentIndex].duration}
+                onControlsVisibilityChange={onActiveVideoControlsVisibilityChange}
                 poster={sortedItems[currentIndex].thumbnail || undefined}
                 src={sortedItems[currentIndex].src}
               />

--- a/apps/web/components/shared/video-player.tsx
+++ b/apps/web/components/shared/video-player.tsx
@@ -24,11 +24,19 @@ export interface VideoPlayerProps {
   duration?: number | null;
   poster?: string;
   className?: string;
+  onControlsVisibilityChange?: (visible: boolean) => void;
 }
 
-export default function VideoPlayer({ src, duration, poster, className = "" }: VideoPlayerProps) {
+export default function VideoPlayer({
+  src,
+  duration,
+  poster,
+  className = "",
+  onControlsVisibilityChange,
+}: VideoPlayerProps) {
   const videoRef = useRef<HTMLVideoElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const touchControlsHideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const t = useTranslations("recipes.carousel.videoPlayer");
 
@@ -231,18 +239,39 @@ export default function VideoPlayer({ src, duration, poster, className = "" }: V
     setIsLoading(false);
   };
 
+  const clearTouchControlsHideTimer = useCallback(() => {
+    if (touchControlsHideTimerRef.current) {
+      clearTimeout(touchControlsHideTimerRef.current);
+      touchControlsHideTimerRef.current = null;
+    }
+  }, []);
+
   const handleTouchStart = () => {
+    clearTouchControlsHideTimer();
     setShowControls(true);
     // Hide controls after 2.5 seconds of no interaction
-    const timer = setTimeout(() => setShowControls(false), 2500);
-
-    return () => clearTimeout(timer);
+    touchControlsHideTimerRef.current = setTimeout(() => {
+      setShowControls(false);
+      touchControlsHideTimerRef.current = null;
+    }, 2500);
   };
 
   // Tap to play/pause
   const handleTap = (_e: React.MouseEvent | React.TouchEvent) => {
     togglePlay();
   };
+
+  const areControlsVisible = showControls || !isPlaying;
+
+  useEffect(() => {
+    onControlsVisibilityChange?.(areControlsVisible);
+  }, [areControlsVisible, onControlsVisibilityChange]);
+
+  useEffect(() => {
+    return () => {
+      clearTouchControlsHideTimer();
+    };
+  }, [clearTouchControlsHideTimer]);
 
   return (
     <div
@@ -291,7 +320,7 @@ export default function VideoPlayer({ src, duration, poster, className = "" }: V
 
       {/* Controls Overlay */}
       <AnimatePresence>
-        {(showControls || !isPlaying) && (
+        {areControlsVisible && (
           <motion.div
             animate={{ opacity: 1 }}
             className="pointer-events-none absolute inset-0 bg-gradient-to-b from-black/40 via-transparent to-black/60"
@@ -314,7 +343,7 @@ export default function VideoPlayer({ src, duration, poster, className = "" }: V
 
             {/* Bottom: Mute, Progress & Time */}
             <div className="pointer-events-auto absolute right-0 bottom-0 left-0 space-y-2 p-4">
-              <div className="flex items-center justify-between px-1 pr-16 text-xs font-medium text-white/90 sm:pr-1">
+              <div className="flex items-center justify-between px-1 text-xs font-medium text-white/90">
                 <div className="flex items-center gap-2">
                   <Button
                     isIconOnly


### PR DESCRIPTION
## Description

When the video controls are visible on mobile, the `Favorite` button rises to make space for the video controls.
Lowers if an image is shown or the controls are hidden.

Before:
<img width="374" height="122" alt="vivaldi_9uOBBHUwsQ" src="https://github.com/user-attachments/assets/4a52e936-e676-46ca-ac65-f5d0cc62c95f" />

After:
<img width="373" height="160" alt="vivaldi_zEnY99UhIC" src="https://github.com/user-attachments/assets/c86bf2dc-ec58-4e66-a01b-a795563acddc" />

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] Other (please describe):

## Checklist

<!-- Mark the appropriate options with an "x" -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published