### PR TITLE
feat: Italian locale, Italian recipe support

### DIFF
--- a/packages/config/src/recurrence-config.default.json
+++ b/packages/config/src/recurrence-config.default.json
@@ -307,6 +307,62 @@
           "rule": "week"
         }
       ]
+    },
+    "it": {
+      "everyWords": ["ogni"],
+      "otherWords": ["altro", "altra"],
+      "onWords": ["il", "di"],
+      "numberWords": {
+        "un": 1,
+        "uno": 1,
+        "due": 2,
+        "tre": 3,
+        "quattro": 4,
+        "cinque": 5,
+        "sei": 6,
+        "sette": 7,
+        "otto": 8,
+        "nove": 9,
+        "dieci": 10
+      },
+      "unitWords": {
+        "day": ["giorno", "giorni", "giornaliero", "quotidiano"],
+        "week": ["settimana", "settimane", "settimanale"],
+        "month": ["mese", "mesi", "mensile"]
+      },
+      "weekdayWords": {
+        "domenica": 0,
+        "dom": 0,
+        "lunedì": 1,
+        "lunedi": 1,
+        "lun": 1,
+        "martedì": 2,
+        "martedi": 2,
+        "mar": 2,
+        "mercoledì": 3,
+        "mercoledi": 3,
+        "mer": 3,
+        "giovedì": 4,
+        "giovedi": 4,
+        "gio": 4,
+        "venerdì": 5,
+        "venerdi": 5,
+        "ven": 5,
+        "sabato": 6,
+        "sab": 6
+      },
+      "intervalHints": [
+        {
+          "phrases": ["ogni due settimane"],
+          "interval": 2,
+          "rule": "week"
+        },
+        {
+          "phrases": ["a giorni alterni", "ogni due giorni"],
+          "interval": 2,
+          "rule": "day"
+        }
+      ]
     }
   }
 }

--- a/packages/config/src/server-config-loader.ts
+++ b/packages/config/src/server-config-loader.ts
@@ -244,6 +244,7 @@ export const DEFAULT_LOCALE_CONFIG: I18nLocaleConfig = {
     ko: { name: "한국어", enabled: true },
     pl: { name: "Polski", enabled: true },
     da: { name: "Dansk", enabled: true },
+    it: { name: "Italiano", enabled: true },
   },
 };
 

--- a/packages/config/src/timer-keywords.default.json
+++ b/packages/config/src/timer-keywords.default.json
@@ -14,12 +14,14 @@
     "uur",
     "uren",
     "u",
+    "ora",
+    "ore",
     "time",
     "timer",
     "시간",
     "시"
   ],
-  "minutes": ["minute", "minutes", "min", "mins", "m", "minuten", "minuut", "minut", "minutter", "분"],
+  "minutes": ["minute", "minutes", "min", "mins", "m", "minuten", "minuut", "minut", "minutter", "minuto", "minuti", "분"],
   "seconds": [
     "second",
     "seconds",
@@ -33,6 +35,8 @@
     "secondes",
     "sekund",
     "sekunder",
+    "secondo",
+    "secondi",
     "초"
   ]
 }

--- a/packages/config/src/units.default.json
+++ b/packages/config/src/units.default.json
@@ -20,6 +20,10 @@
       {
         "locale": "da",
         "name": "cl"
+      },
+      {
+        "locale": "it",
+        "name": "cl"
       }
     ],
     "plural": [
@@ -42,6 +46,10 @@
       {
         "locale": "da",
         "name": "cl"
+      },
+      {
+        "locale": "it",
+        "name": "cl"
       }
     ],
     "alternates": [
@@ -49,7 +57,9 @@
       "centiliters",
       "zentiliter",
       "cl.",
-      "센티리터"
+      "센티리터",
+      "centilitro",
+      "centilitri"
     ]
   },
   "deciliter": {
@@ -73,6 +83,10 @@
       {
         "locale": "da",
         "name": "dl"
+      },
+      {
+        "locale": "it",
+        "name": "dl"
       }
     ],
     "plural": [
@@ -95,6 +109,10 @@
       {
         "locale": "da",
         "name": "dl"
+      },
+      {
+        "locale": "it",
+        "name": "dl"
       }
     ],
     "alternates": [
@@ -102,7 +120,9 @@
       "deciliters",
       "deziliter",
       "dl.",
-      "데시리터"
+      "데시리터",
+      "decilitro",
+      "decilitri"
     ]
   },
   "gram": {
@@ -126,6 +146,10 @@
       {
         "locale": "da",
         "name": "g"
+      },
+      {
+        "locale": "it",
+        "name": "g"
       }
     ],
     "plural": [
@@ -148,6 +172,10 @@
       {
         "locale": "da",
         "name": "g"
+      },
+      {
+        "locale": "it",
+        "name": "g"
       }
     ],
     "alternates": [
@@ -159,7 +187,9 @@
       "gramm",
       "grammen",
       "그램",
-      "그람"
+      "그람",
+      "grammo",
+      "grammi"
     ]
   },
   "teaspoon": {
@@ -183,6 +213,10 @@
       {
         "locale": "da",
         "name": "tsk"
+      },
+      {
+        "locale": "it",
+        "name": "cucchiaino"
       }
     ],
     "plural": [
@@ -205,6 +239,10 @@
       {
         "locale": "da",
         "name": "tsk"
+      },
+      {
+        "locale": "it",
+        "name": "cucchiaini"
       }
     ],
     "alternates": [
@@ -224,7 +262,10 @@
       "t",
       "tsk.",
       "teskefuld",
-      "teskefulde"
+      "teskefulde",
+      "cucchiaino",
+      "cucchiaini",
+      "cc"
     ]
   },
   "tablespoon": {
@@ -248,6 +289,10 @@
       {
         "locale": "da",
         "name": "spsk"
+      },
+      {
+        "locale": "it",
+        "name": "cucchiaio"
       }
     ],
     "plural": [
@@ -270,6 +315,10 @@
       {
         "locale": "da",
         "name": "spsk"
+      },
+      {
+        "locale": "it",
+        "name": "cucchiai"
       }
     ],
     "alternates": [
@@ -286,7 +335,10 @@
       "T",
       "spsk.",
       "spiseskefuld",
-      "spiseskefulde"
+      "spiseskefulde",
+      "cucchiaio",
+      "cucchiai",
+      "cucchiaiate"
     ]
   },
   "knife_tip": {
@@ -310,6 +362,10 @@
       {
         "locale": "da",
         "name": "knivspids"
+      },
+      {
+        "locale": "it",
+        "name": "punta di coltello"
       }
     ],
     "plural": [
@@ -332,6 +388,10 @@
       {
         "locale": "da",
         "name": "knivspidser"
+      },
+      {
+        "locale": "it",
+        "name": "punte di coltello"
       }
     ],
     "alternates": [
@@ -345,7 +405,9 @@
       "칼끝",
       "칼끝만큼",
       "knsp",
-      "knsp."
+      "knsp.",
+      "punta di coltello",
+      "punte di coltello"
     ]
   },
   "pinch": {
@@ -369,6 +431,10 @@
       {
         "locale": "da",
         "name": "nip"
+      },
+      {
+        "locale": "it",
+        "name": "pizzico"
       }
     ],
     "plural": [
@@ -391,6 +457,10 @@
       {
         "locale": "da",
         "name": "nip"
+      },
+      {
+        "locale": "it",
+        "name": "pizzichi"
       }
     ],
     "alternates": [
@@ -408,7 +478,10 @@
       "꼬집",
       "약간",
       "et nip",
-      "drys"
+      "drys",
+      "pizzico",
+      "pizzichi",
+      "un pizzico"
     ]
   },
   "piece": {
@@ -432,6 +505,10 @@
       {
         "locale": "da",
         "name": "stk."
+      },
+      {
+        "locale": "it",
+        "name": "pezzo"
       }
     ],
     "plural": [
@@ -454,6 +531,10 @@
       {
         "locale": "da",
         "name": "stk."
+      },
+      {
+        "locale": "it",
+        "name": "pezzi"
       }
     ],
     "alternates": [
@@ -477,7 +558,11 @@
       "모",
       "토막",
       "styk",
-      "styks"
+      "styks",
+      "pezzo",
+      "pezzi",
+      "pz",
+      "pz."
     ]
   },
   "clove": {
@@ -501,6 +586,10 @@
       {
         "locale": "da",
         "name": "fed"
+      },
+      {
+        "locale": "it",
+        "name": "spicchio"
       }
     ],
     "plural": [
@@ -523,6 +612,10 @@
       {
         "locale": "da",
         "name": "fed"
+      },
+      {
+        "locale": "it",
+        "name": "spicchi"
       }
     ],
     "alternates": [
@@ -534,7 +627,9 @@
       "tenen",
       "쪽",
       "톨",
-      "hvidløgsfed"
+      "hvidløgsfed",
+      "spicchio",
+      "spicchi"
     ]
   },
   "leaf": {
@@ -558,6 +653,10 @@
       {
         "locale": "da",
         "name": "blad"
+      },
+      {
+        "locale": "it",
+        "name": "foglia"
       }
     ],
     "plural": [
@@ -580,6 +679,10 @@
       {
         "locale": "da",
         "name": "blade"
+      },
+      {
+        "locale": "it",
+        "name": "foglie"
       }
     ],
     "alternates": [
@@ -590,7 +693,11 @@
       "leaf",
       "leaves",
       "잎",
-      "장"
+      "장",
+      "foglia",
+      "foglie",
+      "foglietta",
+      "foglioline"
     ]
   },
   "sprig": {
@@ -614,6 +721,10 @@
       {
         "locale": "da",
         "name": "kvist"
+      },
+      {
+        "locale": "it",
+        "name": "rametto"
       }
     ],
     "plural": [
@@ -636,6 +747,10 @@
       {
         "locale": "da",
         "name": "kviste"
+      },
+      {
+        "locale": "it",
+        "name": "rametti"
       }
     ],
     "alternates": [
@@ -655,7 +770,9 @@
       "줄기",
       "가지",
       "stilk",
-      "stilke"
+      "stilke",
+      "rametto",
+      "rametti"
     ]
   },
   "bunch": {
@@ -679,6 +796,10 @@
       {
         "locale": "da",
         "name": "bundt"
+      },
+      {
+        "locale": "it",
+        "name": "mazzo"
       }
     ],
     "plural": [
@@ -701,6 +822,10 @@
       {
         "locale": "da",
         "name": "bundter"
+      },
+      {
+        "locale": "it",
+        "name": "mazzi"
       }
     ],
     "alternates": [
@@ -715,7 +840,11 @@
       "büschel",
       "다발",
       "한단",
-      "단"
+      "단",
+      "mazzo",
+      "mazzi",
+      "mazzetto",
+      "mazzetti"
     ]
   },
   "stalk": {
@@ -739,6 +868,10 @@
       {
         "locale": "da",
         "name": "stængel"
+      },
+      {
+        "locale": "it",
+        "name": "gambo"
       }
     ],
     "plural": [
@@ -761,6 +894,10 @@
       {
         "locale": "da",
         "name": "stængler"
+      },
+      {
+        "locale": "it",
+        "name": "gambi"
       }
     ],
     "alternates": [
@@ -769,7 +906,9 @@
       "대",
       "줄기",
       "stilk",
-      "stilke"
+      "stilke",
+      "gambo",
+      "gambi"
     ]
   },
   "pack": {
@@ -793,6 +932,10 @@
       {
         "locale": "da",
         "name": "pakke"
+      },
+      {
+        "locale": "it",
+        "name": "conf."
       }
     ],
     "plural": [
@@ -815,6 +958,10 @@
       {
         "locale": "da",
         "name": "pakker"
+      },
+      {
+        "locale": "it",
+        "name": "conf."
       }
     ],
     "alternates": [
@@ -838,7 +985,11 @@
       "봉",
       "봉지",
       "포",
-      "pk."
+      "pk.",
+      "confezione",
+      "confezioni",
+      "conf",
+      "conf."
     ]
   },
   "can": {
@@ -862,6 +1013,10 @@
       {
         "locale": "da",
         "name": "dåse"
+      },
+      {
+        "locale": "it",
+        "name": "lattina"
       }
     ],
     "plural": [
@@ -884,6 +1039,10 @@
       {
         "locale": "da",
         "name": "dåser"
+      },
+      {
+        "locale": "it",
+        "name": "lattine"
       }
     ],
     "alternates": [
@@ -906,7 +1065,11 @@
       "kleine dosen",
       "tin",
       "캔",
-      "통"
+      "통",
+      "lattina",
+      "lattine",
+      "barattolo",
+      "barattoli"
     ]
   },
   "jar": {
@@ -930,6 +1093,10 @@
       {
         "locale": "da",
         "name": "glas"
+      },
+      {
+        "locale": "it",
+        "name": "vasetto"
       }
     ],
     "plural": [
@@ -952,6 +1119,10 @@
       {
         "locale": "da",
         "name": "glas"
+      },
+      {
+        "locale": "it",
+        "name": "vasetti"
       }
     ],
     "alternates": [
@@ -965,7 +1136,11 @@
       "pot",
       "potten",
       "병",
-      "유리병"
+      "유리병",
+      "vasetto",
+      "vasetti",
+      "barattolo",
+      "barattoli"
     ]
   },
   "bottle": {
@@ -989,6 +1164,10 @@
       {
         "locale": "da",
         "name": "fl."
+      },
+      {
+        "locale": "it",
+        "name": "bottiglia"
       }
     ],
     "plural": [
@@ -1011,6 +1190,10 @@
       {
         "locale": "da",
         "name": "flasker"
+      },
+      {
+        "locale": "it",
+        "name": "bottiglie"
       }
     ],
     "alternates": [
@@ -1027,7 +1210,9 @@
       "flesjes",
       "flessen",
       "fläschchen",
-      "병"
+      "병",
+      "bottiglia",
+      "bottiglie"
     ]
   },
   "bag": {
@@ -1051,6 +1236,10 @@
       {
         "locale": "da",
         "name": "pose"
+      },
+      {
+        "locale": "it",
+        "name": "sacchetto"
       }
     ],
     "plural": [
@@ -1073,6 +1262,10 @@
       {
         "locale": "da",
         "name": "poser"
+      },
+      {
+        "locale": "it",
+        "name": "sacchetti"
       }
     ],
     "alternates": [
@@ -1090,7 +1283,11 @@
       "zakjes",
       "zakken",
       "봉지",
-      "자루"
+      "자루",
+      "sacchetto",
+      "sacchetti",
+      "busta",
+      "buste"
     ]
   },
   "box": {
@@ -1114,6 +1311,10 @@
       {
         "locale": "da",
         "name": "æske"
+      },
+      {
+        "locale": "it",
+        "name": "scatola"
       }
     ],
     "plural": [
@@ -1136,6 +1337,10 @@
       {
         "locale": "da",
         "name": "æsker"
+      },
+      {
+        "locale": "it",
+        "name": "scatole"
       }
     ],
     "alternates": [
@@ -1147,7 +1352,9 @@
       "doosjes",
       "dozen",
       "박스",
-      "상자"
+      "상자",
+      "scatola",
+      "scatole"
     ]
   },
   "handful": {
@@ -1171,6 +1378,10 @@
       {
         "locale": "da",
         "name": "håndfuld"
+      },
+      {
+        "locale": "it",
+        "name": "manciata"
       }
     ],
     "plural": [
@@ -1193,6 +1404,10 @@
       {
         "locale": "da",
         "name": "håndfulde"
+      },
+      {
+        "locale": "it",
+        "name": "manciate"
       }
     ],
     "alternates": [
@@ -1207,7 +1422,10 @@
       "hdv",
       "hdv.",
       "한줌",
-      "줌"
+      "줌",
+      "manciata",
+      "manciate",
+      "una manciata"
     ]
   },
   "splash": {
@@ -1231,6 +1449,10 @@
       {
         "locale": "da",
         "name": "skvæt"
+      },
+      {
+        "locale": "it",
+        "name": "spruzzo"
       }
     ],
     "plural": [
@@ -1253,6 +1475,10 @@
       {
         "locale": "da",
         "name": "skvæt"
+      },
+      {
+        "locale": "it",
+        "name": "spruzzi"
       }
     ],
     "alternates": [
@@ -1268,7 +1494,10 @@
       "조금",
       "et skvæt",
       "slat",
-      "slatter"
+      "slatter",
+      "spruzzo",
+      "spruzzi",
+      "schizzo"
     ]
   },
   "cup": {
@@ -1292,6 +1521,10 @@
       {
         "locale": "da",
         "name": "kop"
+      },
+      {
+        "locale": "it",
+        "name": "tazza"
       }
     ],
     "plural": [
@@ -1314,6 +1547,10 @@
       {
         "locale": "da",
         "name": "kopper"
+      },
+      {
+        "locale": "it",
+        "name": "tazze"
       }
     ],
     "alternates": [
@@ -1336,7 +1573,11 @@
       "tässchen",
       "컵",
       "공기",
-      "pægl"
+      "pægl",
+      "tazza",
+      "tazze",
+      "tazzina",
+      "tazzine"
     ]
   },
   "glass": {
@@ -1360,6 +1601,10 @@
       {
         "locale": "da",
         "name": "glas"
+      },
+      {
+        "locale": "it",
+        "name": "bicchiere"
       }
     ],
     "plural": [
@@ -1382,6 +1627,10 @@
       {
         "locale": "da",
         "name": "glas"
+      },
+      {
+        "locale": "it",
+        "name": "bicchieri"
       }
     ],
     "alternates": [
@@ -1394,7 +1643,9 @@
       "kleines glas",
       "shotglas",
       "잔",
-      "컵"
+      "컵",
+      "bicchiere",
+      "bicchieri"
     ]
   },
   "slice": {
@@ -1418,6 +1669,10 @@
       {
         "locale": "da",
         "name": "skive"
+      },
+      {
+        "locale": "it",
+        "name": "fetta"
       }
     ],
     "plural": [
@@ -1440,6 +1695,10 @@
       {
         "locale": "da",
         "name": "skiver"
+      },
+      {
+        "locale": "it",
+        "name": "fette"
       }
     ],
     "alternates": [
@@ -1454,7 +1713,9 @@
       "slice",
       "slices",
       "조각",
-      "슬라이스"
+      "슬라이스",
+      "fetta",
+      "fette"
     ]
   },
   "strip": {
@@ -1478,6 +1739,10 @@
       {
         "locale": "da",
         "name": "strimmel"
+      },
+      {
+        "locale": "it",
+        "name": "striscia"
       }
     ],
     "plural": [
@@ -1500,6 +1765,10 @@
       {
         "locale": "da",
         "name": "strimler"
+      },
+      {
+        "locale": "it",
+        "name": "strisce"
       }
     ],
     "alternates": [
@@ -1509,7 +1778,11 @@
       "strip",
       "strips",
       "채",
-      "가늘게썬조각"
+      "가늘게썬조각",
+      "striscia",
+      "strisce",
+      "listarella",
+      "listarelle"
     ]
   },
   "sheet": {
@@ -1533,6 +1806,10 @@
       {
         "locale": "da",
         "name": "ark"
+      },
+      {
+        "locale": "it",
+        "name": "foglio"
       }
     ],
     "plural": [
@@ -1555,6 +1832,10 @@
       {
         "locale": "da",
         "name": "ark"
+      },
+      {
+        "locale": "it",
+        "name": "fogli"
       }
     ],
     "alternates": [
@@ -1562,7 +1843,9 @@
       "vellen",
       "velletje",
       "velletjes",
-      "장"
+      "장",
+      "foglio",
+      "fogli"
     ]
   },
   "serving": {
@@ -1586,6 +1869,10 @@
       {
         "locale": "da",
         "name": "portion"
+      },
+      {
+        "locale": "it",
+        "name": "porzione"
       }
     ],
     "plural": [
@@ -1608,6 +1895,10 @@
       {
         "locale": "da",
         "name": "portioner"
+      },
+      {
+        "locale": "it",
+        "name": "porzioni"
       }
     ],
     "alternates": [
@@ -1619,7 +1910,9 @@
       "portions",
       "serving",
       "servings",
-      "인분"
+      "인분",
+      "porzione",
+      "porzioni"
     ]
   },
   "round_slice": {
@@ -1643,6 +1936,10 @@
       {
         "locale": "da",
         "name": "skive"
+      },
+      {
+        "locale": "it",
+        "name": "rondella"
       }
     ],
     "plural": [
@@ -1665,6 +1962,10 @@
       {
         "locale": "da",
         "name": "skiver"
+      },
+      {
+        "locale": "it",
+        "name": "rondelle"
       }
     ],
     "alternates": [
@@ -1674,7 +1975,9 @@
       "둥근 조각",
       "동그랗게 썬 것",
       "rundskive",
-      "rundtenom"
+      "rundtenom",
+      "rondella",
+      "rondelle"
     ]
   },
   "ring": {
@@ -1698,6 +2001,10 @@
       {
         "locale": "da",
         "name": "ring"
+      },
+      {
+        "locale": "it",
+        "name": "anello"
       }
     ],
     "plural": [
@@ -1720,6 +2027,10 @@
       {
         "locale": "da",
         "name": "ringe"
+      },
+      {
+        "locale": "it",
+        "name": "anelli"
       }
     ],
     "alternates": [
@@ -1728,7 +2039,9 @@
       "ringlein",
       "링",
       "고리 모양",
-      "ringe"
+      "ringe",
+      "anello",
+      "anelli"
     ]
   },
   "ball": {
@@ -1752,6 +2065,10 @@
       {
         "locale": "da",
         "name": "kugle"
+      },
+      {
+        "locale": "it",
+        "name": "pallina"
       }
     ],
     "plural": [
@@ -1774,6 +2091,10 @@
       {
         "locale": "da",
         "name": "kugler"
+      },
+      {
+        "locale": "it",
+        "name": "palline"
       }
     ],
     "alternates": [
@@ -1784,7 +2105,9 @@
       "kügelchen",
       "알",
       "경단",
-      "볼"
+      "볼",
+      "pallina",
+      "palline"
     ]
   },
   "dash": {
@@ -1808,6 +2131,10 @@
       {
         "locale": "da",
         "name": "stænk"
+      },
+      {
+        "locale": "it",
+        "name": "goccio"
       }
     ],
     "plural": [
@@ -1830,6 +2157,10 @@
       {
         "locale": "da",
         "name": "stænk"
+      },
+      {
+        "locale": "it",
+        "name": "gocci"
       }
     ],
     "alternates": [
@@ -1838,7 +2169,10 @@
       "dashes",
       "약간",
       "소량",
-      "et stænk"
+      "et stænk",
+      "goccio",
+      "gocci",
+      "un goccio"
     ]
   },
   "drizzle": {
@@ -1862,6 +2196,10 @@
       {
         "locale": "da",
         "name": "dryp"
+      },
+      {
+        "locale": "it",
+        "name": "filo"
       }
     ],
     "plural": [
@@ -1884,6 +2222,10 @@
       {
         "locale": "da",
         "name": "dryp"
+      },
+      {
+        "locale": "it",
+        "name": "fili"
       }
     ],
     "alternates": [
@@ -1892,7 +2234,10 @@
       "drizzles",
       "spritzerchen",
       "살짝",
-      "뿌림"
+      "뿌림",
+      "filo",
+      "fili",
+      "un filo"
     ]
   },
   "scoop": {
@@ -1916,6 +2261,10 @@
       {
         "locale": "da",
         "name": "kugle"
+      },
+      {
+        "locale": "it",
+        "name": "pallina"
       }
     ],
     "plural": [
@@ -1938,13 +2287,19 @@
       {
         "locale": "da",
         "name": "kugler"
+      },
+      {
+        "locale": "it",
+        "name": "palline"
       }
     ],
     "alternates": [
       "scoop",
       "scoops",
       "스쿱",
-      "국자"
+      "국자",
+      "pallina",
+      "palline"
     ]
   },
   "stick": {
@@ -1968,6 +2323,10 @@
       {
         "locale": "da",
         "name": "stang"
+      },
+      {
+        "locale": "it",
+        "name": "bastoncino"
       }
     ],
     "plural": [
@@ -1990,6 +2349,10 @@
       {
         "locale": "da",
         "name": "stænger"
+      },
+      {
+        "locale": "it",
+        "name": "bastoncini"
       }
     ],
     "alternates": [
@@ -1998,7 +2361,11 @@
       "sticks",
       "stänglein",
       "막대",
-      "스틱"
+      "스틱",
+      "bastoncino",
+      "bastoncini",
+      "stecca",
+      "stecche"
     ]
   },
   "tub": {
@@ -2022,6 +2389,10 @@
       {
         "locale": "da",
         "name": "bæger"
+      },
+      {
+        "locale": "it",
+        "name": "vaschetta"
       }
     ],
     "plural": [
@@ -2044,6 +2415,10 @@
       {
         "locale": "da",
         "name": "bægre"
+      },
+      {
+        "locale": "it",
+        "name": "vaschette"
       }
     ],
     "alternates": [
@@ -2051,7 +2426,11 @@
       "tub",
       "tubs",
       "통",
-      "용기"
+      "용기",
+      "vaschetta",
+      "vaschette",
+      "contenitore",
+      "contenitori"
     ]
   },
   "capful": {
@@ -2075,6 +2454,10 @@
       {
         "locale": "da",
         "name": "hætte"
+      },
+      {
+        "locale": "it",
+        "name": "tappo"
       }
     ],
     "plural": [
@@ -2097,6 +2480,10 @@
       {
         "locale": "da",
         "name": "hætter"
+      },
+      {
+        "locale": "it",
+        "name": "tappi"
       }
     ],
     "alternates": [
@@ -2104,7 +2491,10 @@
       "capful",
       "capfuls",
       "뚜껑",
-      "캡"
+      "캡",
+      "tappo",
+      "tappi",
+      "un tappo"
     ]
   },
   "pouch": {
@@ -2128,6 +2518,10 @@
       {
         "locale": "da",
         "name": "pose"
+      },
+      {
+        "locale": "it",
+        "name": "bustina"
       }
     ],
     "plural": [
@@ -2150,13 +2544,19 @@
       {
         "locale": "da",
         "name": "poser"
+      },
+      {
+        "locale": "it",
+        "name": "bustine"
       }
     ],
     "alternates": [
       "pouch",
       "pouches",
       "파우치",
-      "주머니"
+      "주머니",
+      "bustina",
+      "bustine"
     ]
   },
   "sleeve": {
@@ -2180,6 +2580,10 @@
       {
         "locale": "da",
         "name": "omslag"
+      },
+      {
+        "locale": "it",
+        "name": "confezione"
       }
     ],
     "plural": [
@@ -2202,13 +2606,19 @@
       {
         "locale": "da",
         "name": "omslag"
+      },
+      {
+        "locale": "it",
+        "name": "confezioni"
       }
     ],
     "alternates": [
       "sleeve",
       "sleeves",
       "봉지",
-      "묶음"
+      "묶음",
+      "confezione",
+      "confezioni"
     ]
   },
   "roll": {
@@ -2232,6 +2642,10 @@
       {
         "locale": "da",
         "name": "rulle"
+      },
+      {
+        "locale": "it",
+        "name": "rotolo"
       }
     ],
     "plural": [
@@ -2254,6 +2668,10 @@
       {
         "locale": "da",
         "name": "ruller"
+      },
+      {
+        "locale": "it",
+        "name": "rotoli"
       }
     ],
     "alternates": [
@@ -2261,7 +2679,11 @@
       "rolls",
       "röllchen",
       "롤",
-      "말이"
+      "말이",
+      "rotolo",
+      "rotoli",
+      "rotolino",
+      "rotolini"
     ]
   },
   "ear": {
@@ -2285,6 +2707,10 @@
       {
         "locale": "da",
         "name": "kolbe"
+      },
+      {
+        "locale": "it",
+        "name": "pannocchia"
       }
     ],
     "plural": [
@@ -2307,6 +2733,10 @@
       {
         "locale": "da",
         "name": "kolber"
+      },
+      {
+        "locale": "it",
+        "name": "pannocchie"
       }
     ],
     "alternates": [
@@ -2316,7 +2746,9 @@
       "ears of corn",
       "개",
       "이삭",
-      "majskolbe"
+      "majskolbe",
+      "pannocchia",
+      "pannocchie"
     ]
   },
   "wedge": {
@@ -2340,6 +2772,10 @@
       {
         "locale": "da",
         "name": "båd"
+      },
+      {
+        "locale": "it",
+        "name": "spicchio"
       }
     ],
     "plural": [
@@ -2362,6 +2798,10 @@
       {
         "locale": "da",
         "name": "både"
+      },
+      {
+        "locale": "it",
+        "name": "spicchi"
       }
     ],
     "alternates": [
@@ -2369,7 +2809,9 @@
       "keil",
       "wedge",
       "wedges",
-      "쪽"
+      "쪽",
+      "spicchio",
+      "spicchi"
     ]
   },
   "chunk": {
@@ -2393,6 +2835,10 @@
       {
         "locale": "da",
         "name": "klump"
+      },
+      {
+        "locale": "it",
+        "name": "pezzo"
       }
     ],
     "plural": [
@@ -2415,13 +2861,21 @@
       {
         "locale": "da",
         "name": "klumper"
+      },
+      {
+        "locale": "it",
+        "name": "pezzi"
       }
     ],
     "alternates": [
       "chunk",
       "chunks",
       "덩어리",
-      "토막"
+      "토막",
+      "pezzo",
+      "pezzi",
+      "tocco",
+      "tocchi"
     ]
   },
   "cube": {
@@ -2445,6 +2899,10 @@
       {
         "locale": "da",
         "name": "terning"
+      },
+      {
+        "locale": "it",
+        "name": "cubetto"
       }
     ],
     "plural": [
@@ -2467,6 +2925,10 @@
       {
         "locale": "da",
         "name": "terninger"
+      },
+      {
+        "locale": "it",
+        "name": "cubetti"
       }
     ],
     "alternates": [
@@ -2474,7 +2936,11 @@
       "cubes",
       "würfelchen",
       "깍둑썰기",
-      "큐브"
+      "큐브",
+      "cubetto",
+      "cubetti",
+      "dado",
+      "dadi"
     ]
   },
   "fillet": {
@@ -2498,6 +2964,10 @@
       {
         "locale": "da",
         "name": "filet"
+      },
+      {
+        "locale": "it",
+        "name": "filetto"
       }
     ],
     "plural": [
@@ -2520,6 +2990,10 @@
       {
         "locale": "da",
         "name": "fileter"
+      },
+      {
+        "locale": "it",
+        "name": "filetti"
       }
     ],
     "alternates": [
@@ -2529,7 +3003,9 @@
       "fillets",
       "토막",
       "필렛",
-      "필레"
+      "필레",
+      "filetto",
+      "filetti"
     ]
   },
   "heaping_tablespoon": {
@@ -2553,6 +3029,10 @@
       {
         "locale": "da",
         "name": "toppet spsk"
+      },
+      {
+        "locale": "it",
+        "name": "cucchiaio colmo"
       }
     ],
     "plural": [
@@ -2575,6 +3055,10 @@
       {
         "locale": "da",
         "name": "toppet spsk"
+      },
+      {
+        "locale": "it",
+        "name": "cucchiai colmi"
       }
     ],
     "alternates": [
@@ -2600,7 +3084,9 @@
       "spiseske med top",
       "spsk med top",
       "spsk m. top",
-      "spsk. m. top"
+      "spsk. m. top",
+      "cucchiaio colmo",
+      "cucchiai colmi"
     ]
   },
   "scant_tablespoon": {
@@ -2624,6 +3110,10 @@
       {
         "locale": "da",
         "name": "strøget spsk"
+      },
+      {
+        "locale": "it",
+        "name": "cucchiaio raso"
       }
     ],
     "plural": [
@@ -2646,6 +3136,10 @@
       {
         "locale": "da",
         "name": "strøget spsk"
+      },
+      {
+        "locale": "it",
+        "name": "cucchiai rasi"
       }
     ],
     "alternates": [
@@ -2666,7 +3160,9 @@
       "깎은 큰술",
       "strøget spsk.",
       "strøget spiseskefuld",
-      "strøget spiseske"
+      "strøget spiseske",
+      "cucchiaio raso",
+      "cucchiai rasi"
     ]
   },
   "generous_pinch": {
@@ -2690,6 +3186,10 @@
       {
         "locale": "da",
         "name": "godt nip"
+      },
+      {
+        "locale": "it",
+        "name": "pizzico abbondante"
       }
     ],
     "plural": [
@@ -2712,6 +3212,10 @@
       {
         "locale": "da",
         "name": "gode nip"
+      },
+      {
+        "locale": "it",
+        "name": "pizzichi abbondanti"
       }
     ],
     "alternates": [
@@ -2725,7 +3229,10 @@
       "넉넉한 꼬집",
       "큰 꼬집",
       "god knivspids",
-      "stor knivspids"
+      "stor knivspids",
+      "pizzico abbondante",
+      "pizzichi abbondanti",
+      "pizzicone"
     ]
   },
   "large_splash": {
@@ -2749,6 +3256,10 @@
       {
         "locale": "da",
         "name": "stort skvæt"
+      },
+      {
+        "locale": "it",
+        "name": "spruzzo abbondante"
       }
     ],
     "plural": [
@@ -2771,6 +3282,10 @@
       {
         "locale": "da",
         "name": "store skvæt"
+      },
+      {
+        "locale": "it",
+        "name": "spruzzi abbondanti"
       }
     ],
     "alternates": [
@@ -2780,7 +3295,9 @@
       "großer schuß",
       "großzügiger schuss",
       "넉넉히",
-      "godt skvæt"
+      "godt skvæt",
+      "spruzzo abbondante",
+      "spruzzi abbondanti"
     ]
   },
   "dozen": {
@@ -2804,6 +3321,10 @@
       {
         "locale": "da",
         "name": "dusin"
+      },
+      {
+        "locale": "it",
+        "name": "dozzina"
       }
     ],
     "plural": [
@@ -2826,6 +3347,10 @@
       {
         "locale": "da",
         "name": "dusin"
+      },
+      {
+        "locale": "it",
+        "name": "dozzine"
       }
     ],
     "alternates": [
@@ -2833,7 +3358,9 @@
       "dz",
       "dz.",
       "다스",
-      "더즌"
+      "더즌",
+      "dozzina",
+      "dozzine"
     ]
   },
   "small_splash": {
@@ -2857,6 +3384,10 @@
       {
         "locale": "da",
         "name": "lille skvæt"
+      },
+      {
+        "locale": "it",
+        "name": "spruzzino"
       }
     ],
     "plural": [
@@ -2879,6 +3410,10 @@
       {
         "locale": "da",
         "name": "lille skvæt"
+      },
+      {
+        "locale": "it",
+        "name": "spruzzini"
       }
     ],
     "alternates": [
@@ -2886,7 +3421,10 @@
       "winziger schuss",
       "조금",
       "소량",
-      "en smule"
+      "en smule",
+      "spruzzino",
+      "spruzzini",
+      "piccolo spruzzo"
     ]
   },
   "bulb": {
@@ -2910,6 +3448,10 @@
       {
         "locale": "da",
         "name": "hoved"
+      },
+      {
+        "locale": "it",
+        "name": "bulbo"
       }
     ],
     "plural": [
@@ -2932,12 +3474,18 @@
       {
         "locale": "da",
         "name": "hoveder"
+      },
+      {
+        "locale": "it",
+        "name": "bulbi"
       }
     ],
     "alternates": [
       "knöllchen",
       "통",
-      "뿌리"
+      "뿌리",
+      "bulbo",
+      "bulbi"
     ]
   },
   "head": {
@@ -2961,6 +3509,10 @@
       {
         "locale": "da",
         "name": "hoved"
+      },
+      {
+        "locale": "it",
+        "name": "cespo"
       }
     ],
     "plural": [
@@ -2983,12 +3535,20 @@
       {
         "locale": "da",
         "name": "hoveder"
+      },
+      {
+        "locale": "it",
+        "name": "cespi"
       }
     ],
     "alternates": [
       "köpfchen",
       "통",
-      "포기"
+      "포기",
+      "cespo",
+      "cespi",
+      "testa",
+      "teste"
     ]
   },
   "to_taste": {
@@ -3012,6 +3572,10 @@
       {
         "locale": "da",
         "name": "efter smag"
+      },
+      {
+        "locale": "it",
+        "name": "q.b."
       }
     ],
     "plural": [
@@ -3034,6 +3598,10 @@
       {
         "locale": "da",
         "name": "efter smag"
+      },
+      {
+        "locale": "it",
+        "name": "q.b."
       }
     ],
     "alternates": [
@@ -3045,7 +3613,10 @@
       "취향껏",
       "smages til",
       "efter behag",
-      "efter behov"
+      "efter behov",
+      "q.b.",
+      "quanto basta",
+      "a piacere"
     ]
   },
   "pound": {
@@ -3069,6 +3640,10 @@
       {
         "locale": "da",
         "name": "pund"
+      },
+      {
+        "locale": "it",
+        "name": "libbra"
       }
     ],
     "plural": [
@@ -3091,13 +3666,19 @@
       {
         "locale": "da",
         "name": "pund"
+      },
+      {
+        "locale": "it",
+        "name": "libbre"
       }
     ],
     "alternates": [
       "pfd",
       "pfd.",
       "파운드",
-      "lb"
+      "lb",
+      "libbra",
+      "libbre"
     ]
   },
   "bar": {
@@ -3121,6 +3702,10 @@
       {
         "locale": "da",
         "name": "plade"
+      },
+      {
+        "locale": "it",
+        "name": "tavoletta"
       }
     ],
     "plural": [
@@ -3143,13 +3728,21 @@
       {
         "locale": "da",
         "name": "plader"
+      },
+      {
+        "locale": "it",
+        "name": "tavolette"
       }
     ],
     "alternates": [
       "reihen",
       "riegelchen",
       "판",
-      "바"
+      "바",
+      "tavoletta",
+      "tavolette",
+      "barretta",
+      "barrette"
     ]
   },
   "bowl": {
@@ -3173,6 +3766,10 @@
       {
         "locale": "da",
         "name": "skål"
+      },
+      {
+        "locale": "it",
+        "name": "ciotola"
       }
     ],
     "plural": [
@@ -3195,12 +3792,20 @@
       {
         "locale": "da",
         "name": "skåle"
+      },
+      {
+        "locale": "it",
+        "name": "ciotole"
       }
     ],
     "alternates": [
       "schälchen",
       "공기",
-      "그릇"
+      "그릇",
+      "ciotola",
+      "ciotole",
+      "scodella",
+      "scodelle"
     ]
   },
   "heaping_teaspoon": {
@@ -3224,6 +3829,10 @@
       {
         "locale": "da",
         "name": "toppet tsk"
+      },
+      {
+        "locale": "it",
+        "name": "cucchiaino colmo"
       }
     ],
     "plural": [
@@ -3246,6 +3855,10 @@
       {
         "locale": "da",
         "name": "toppede tsk"
+      },
+      {
+        "locale": "it",
+        "name": "cucchiaini colmi"
       }
     ],
     "alternates": [
@@ -3268,7 +3881,9 @@
       "teske med top",
       "tsk med top",
       "tsk m. top",
-      "tsk. m. top"
+      "tsk. m. top",
+      "cucchiaino colmo",
+      "cucchiaini colmi"
     ]
   },
   "scant_teaspoon": {
@@ -3292,6 +3907,10 @@
       {
         "locale": "da",
         "name": "strøget tsk"
+      },
+      {
+        "locale": "it",
+        "name": "cucchiaino raso"
       }
     ],
     "plural": [
@@ -3314,6 +3933,10 @@
       {
         "locale": "da",
         "name": "strøget tsk"
+      },
+      {
+        "locale": "it",
+        "name": "cucchiaini rasi"
       }
     ],
     "alternates": [
@@ -3332,7 +3955,9 @@
       "깎은 작은술",
       "strøget tsk.",
       "strøget teskefuld",
-      "strøget teske"
+      "strøget teske",
+      "cucchiaino raso",
+      "cucchiaini rasi"
     ]
   },
   "pot": {
@@ -3356,6 +3981,10 @@
       {
         "locale": "da",
         "name": "gryde"
+      },
+      {
+        "locale": "it",
+        "name": "pentola"
       }
     ],
     "plural": [
@@ -3378,11 +4007,17 @@
       {
         "locale": "da",
         "name": "gryder"
+      },
+      {
+        "locale": "it",
+        "name": "pentole"
       }
     ],
     "alternates": [
       "냄비",
-      "솥"
+      "솥",
+      "pentola",
+      "pentole"
     ]
   },
   "drop": {
@@ -3406,6 +4041,10 @@
       {
         "locale": "da",
         "name": "dråbe"
+      },
+      {
+        "locale": "it",
+        "name": "goccia"
       }
     ],
     "plural": [
@@ -3428,6 +4067,10 @@
       {
         "locale": "da",
         "name": "dråber"
+      },
+      {
+        "locale": "it",
+        "name": "gocce"
       }
     ],
     "alternates": [
@@ -3439,7 +4082,10 @@
       "trpf.",
       "tröpfchen",
       "방울",
-      "한방울"
+      "한방울",
+      "goccia",
+      "gocce",
+      "goccina"
     ]
   },
   "ounce": {
@@ -3463,6 +4109,10 @@
       {
         "locale": "da",
         "name": "oz"
+      },
+      {
+        "locale": "it",
+        "name": "oncia"
       }
     ],
     "plural": [
@@ -3485,12 +4135,18 @@
       {
         "locale": "da",
         "name": "oz"
+      },
+      {
+        "locale": "it",
+        "name": "once"
       }
     ],
     "alternates": [
       "oz",
       "oz.",
-      "온스"
+      "온스",
+      "oncia",
+      "once"
     ]
   },
   "milliliter": {
@@ -3514,6 +4170,10 @@
       {
         "locale": "da",
         "name": "ml"
+      },
+      {
+        "locale": "it",
+        "name": "ml"
       }
     ],
     "plural": [
@@ -3536,6 +4196,10 @@
       {
         "locale": "da",
         "name": "milliliter"
+      },
+      {
+        "locale": "it",
+        "name": "ml"
       }
     ],
     "alternates": [
@@ -3546,7 +4210,9 @@
       "ml",
       "ml.",
       "밀리리터",
-      "밀리"
+      "밀리",
+      "millilitro",
+      "millilitri"
     ]
   },
   "liter": {
@@ -3570,6 +4236,10 @@
       {
         "locale": "da",
         "name": "l"
+      },
+      {
+        "locale": "it",
+        "name": "l"
       }
     ],
     "plural": [
@@ -3592,6 +4262,10 @@
       {
         "locale": "da",
         "name": "liter"
+      },
+      {
+        "locale": "it",
+        "name": "l"
       }
     ],
     "alternates": [
@@ -3602,7 +4276,9 @@
       "l",
       "l.",
       "L",
-      "리터"
+      "리터",
+      "litro",
+      "litri"
     ]
   },
   "centimeter": {
@@ -3626,6 +4302,10 @@
       {
         "locale": "da",
         "name": "cm"
+      },
+      {
+        "locale": "it",
+        "name": "cm"
       }
     ],
     "plural": [
@@ -3648,6 +4328,10 @@
       {
         "locale": "da",
         "name": "cm"
+      },
+      {
+        "locale": "it",
+        "name": "cm"
       }
     ],
     "alternates": [
@@ -3656,7 +4340,9 @@
       "zentimeter",
       "cm.",
       "센치",
-      "센치미터"
+      "센치미터",
+      "centimetro",
+      "centimetri"
     ]
   }
 }

--- a/packages/i18n/src/messages.ts
+++ b/packages/i18n/src/messages.ts
@@ -102,6 +102,15 @@ const MESSAGE_LOADERS: Record<string, Partial<Record<MessageSection, MessageLoad
     navbar: () => import("./messages/da/navbar.json"),
     auth: () => import("./messages/da/auth.json"),
   },
+  it: {
+    common: () => import("./messages/it/common.json"),
+    recipes: () => import("./messages/it/recipes.json"),
+    groceries: () => import("./messages/it/groceries.json"),
+    calendar: () => import("./messages/it/calendar.json"),
+    settings: () => import("./messages/it/settings.json"),
+    navbar: () => import("./messages/it/navbar.json"),
+    auth: () => import("./messages/it/auth.json"),
+  },
 };
 
 export async function loadLocaleMessages(locale: string): Promise<Record<string, unknown>> {

--- a/packages/i18n/src/messages/it/auth.json
+++ b/packages/i18n/src/messages/it/auth.json
@@ -1,0 +1,126 @@
+{
+  "login": {
+    "title": "Accedi a",
+    "subtitle": "Nutri ogni momento.",
+    "redirectMessage": "Verrai reindirizzato in modo sicuro al tuo provider di accesso.",
+    "noProviders": {
+      "title": "Nessun provider di autenticazione configurato.",
+      "contactAdmin": "Contatta il tuo amministratore."
+    },
+    "divider": "oppure",
+    "wrongServer": "Server sbagliato?",
+    "changeServer": "Cambia server"
+  },
+  "emailPassword": {
+    "email": "Email",
+    "emailPlaceholder": "tu@esempio.com",
+    "password": "Password",
+    "passwordPlaceholder": "Inserisci la tua password",
+    "signIn": "Accedi",
+    "noAccount": "Non hai un account?",
+    "signUp": "Registrati",
+    "errors": {
+      "invalidCredentials": "Email o password non validi",
+      "generic": "Si è verificato un errore. Riprova."
+    }
+  },
+  "signup": {
+    "title": "Registrati a",
+    "subtitle": "Crea il tuo account per iniziare.",
+    "name": "Nome",
+    "namePlaceholder": "Il tuo nome",
+    "email": "Email",
+    "emailPlaceholder": "tu@esempio.com",
+    "password": "Password",
+    "passwordPlaceholder": "Crea una password",
+    "passwordDescription": "Almeno 8 caratteri",
+    "confirmPassword": "Conferma password",
+    "confirmPasswordPlaceholder": "Conferma la tua password",
+    "createAccount": "Crea account",
+    "hasAccount": "Hai già un account?",
+    "signIn": "Accedi",
+    "errors": {
+      "passwordMismatch": "Le password non corrispondono",
+      "passwordTooShort": "La password deve contenere almeno 8 caratteri",
+      "passwordTooLong": "La password può contenere al massimo 128 caratteri",
+      "createFailed": "Creazione dell'account non riuscita",
+      "generic": "Si è verificato un errore. Riprova."
+    }
+  },
+  "errors": {
+    "state_mismatch": {
+      "title": "Sessione scaduta",
+      "description": "La sessione è scaduta o la richiesta non era valida. Riprova."
+    },
+    "invalid_state": {
+      "title": "Richiesta non valida",
+      "description": "La richiesta di accesso non era valida. Riprova."
+    },
+    "access_denied": {
+      "title": "Accesso negato",
+      "description": "Hai negato l'accesso al tuo account. Riprova se è stato un errore."
+    },
+    "oauth_code_verification_failed": {
+      "title": "Verifica non riuscita",
+      "description": "Verifica dell'accesso non riuscita. Riprova."
+    },
+    "unable_to_get_user_info": {
+      "title": "Errore del provider",
+      "description": "Impossibile ottenere le informazioni del tuo account dal provider. Riprova."
+    },
+    "provider_not_found": {
+      "title": "Provider non trovato",
+      "description": "Il provider di autenticazione non è configurato."
+    },
+    "social_account_already_linked": {
+      "title": "Account già collegato",
+      "description": "Questo account social è già collegato a un altro utente."
+    },
+    "account_not_found": {
+      "title": "Account non trovato",
+      "description": "Nessun account trovato."
+    },
+    "registration_is_currently_disabled": {
+      "title": "Registrazione disabilitata",
+      "description": "Le nuove registrazioni sono attualmente disabilitate."
+    },
+    "user_not_found": {
+      "title": "Utente non trovato",
+      "description": "Il tuo account non è stato trovato. La registrazione potrebbe essere disabilitata."
+    },
+    "internal_server_error": {
+      "title": "Errore del server",
+      "description": "Qualcosa è andato storto da parte nostra. Riprova più tardi."
+    },
+    "unauthorized": {
+      "title": "Non autorizzato",
+      "description": "Non sei autorizzato ad accedere a questa risorsa."
+    },
+    "default": {
+      "title": "Errore di autenticazione",
+      "description": "Si è verificato un errore durante l'accesso. Riprova."
+    },
+    "errorCode": "Codice errore: {code}",
+    "backToLogin": "Torna al login"
+  },
+  "provider": {
+    "signInWith": "Accedi con {provider}"
+  },
+  "connect": {
+    "title": "Connetti a",
+    "backendUrlLabel": "URL del backend",
+    "backendUrlPlaceholder": "https://il-tuo-server-norish.com",
+    "connect": "Connetti",
+    "connecting": "Connessione in corso...",
+    "example": "Esempio: https://demo.norish.app o http://localhost:3000",
+    "openConnect": "Apri Connessione",
+    "backendRequiredTitle": "Configurazione del backend richiesta",
+    "backendRequiredDescription": "L'URL del backend non è configurato. Apri Connessione per impostare l'URL del backend Norish.",
+    "errors": {
+      "invalidUrl": "Inserisci un URL valido come https://il-tuo-server.com",
+      "timeout": "Connessione scaduta. Verifica l'URL e l'accesso alla rete.",
+      "unreachable": "Impossibile connettersi all'API o a tRPC su quell'URL del backend.",
+      "unreachableWithReason": "Impossibile connettersi all'API o a tRPC: {reason}"
+    }
+  }
+}

--- a/packages/i18n/src/messages/it/calendar.json
+++ b/packages/i18n/src/messages/it/calendar.json
@@ -1,0 +1,57 @@
+{
+  "page": {
+    "title": "Calendario"
+  },
+  "mobile": {
+    "today": "Oggi",
+    "scrollToToday": "Vai a oggi"
+  },
+  "editNote": {
+    "title": "Modifica nota",
+    "noteLabel": "Nota",
+    "notePlaceholder": "Inserisci nota...",
+    "date": "Data",
+    "slot": "Fascia"
+  },
+  "navigation": {
+    "previousMonth": "Mese precedente",
+    "nextMonth": "Mese successivo",
+    "prev": "Prec",
+    "next": "Succ"
+  },
+  "weekdays": {
+    "mon": "Lun",
+    "tue": "Mar",
+    "wed": "Mer",
+    "thu": "Gio",
+    "fri": "Ven",
+    "sat": "Sab",
+    "sun": "Dom"
+  },
+  "timeline": {
+    "noItems": "Nessun elemento pianificato",
+    "goToRecipe": "Vai alla ricetta",
+    "addItem": "Aggiungi elemento",
+    "untitled": "Senza titolo",
+    "serving": "porzione",
+    "servings": "porzioni",
+    "noImage": "Nessuna immagine",
+    "recipe": "Ricetta",
+    "note": "Nota"
+  },
+  "editPlannedRecipe": {
+    "title": "Modifica ricetta pianificata",
+    "date": "Data",
+    "slot": "Fascia"
+  },
+  "panel": {
+    "addToCalendar": "Aggiungi al calendario",
+    "addRecipe": "Aggiungi ricetta",
+    "noDaysAvailable": "Nessun giorno disponibile.",
+    "searchPlaceholder": "Cerca ricette o aggiungi note...",
+    "addNote": "Aggiungi nota: {input}",
+    "randomRecipe": "Ricetta casuale",
+    "noRecipesFound": "Nessuna ricetta trovata.",
+    "failedToLoadRecipes": "Caricamento ricette non riuscito."
+  }
+}

--- a/packages/i18n/src/messages/it/common.json
+++ b/packages/i18n/src/messages/it/common.json
@@ -1,0 +1,215 @@
+{
+  "actions": {
+    "save": "Salva",
+    "cancel": "Annulla",
+    "delete": "Elimina",
+    "duplicate": "Duplica",
+    "edit": "Modifica",
+    "create": "Crea",
+    "add": "Aggiungi",
+    "remove": "Rimuovi",
+    "close": "Chiudi",
+    "apply": "Applica",
+    "reset": "Reimposta",
+    "clear": "Cancella",
+    "confirm": "Conferma",
+    "back": "Indietro",
+    "next": "Avanti",
+    "done": "Fatto",
+    "retry": "Riprova",
+    "submit": "Invia",
+    "search": "Cerca",
+    "filter": "Filtra",
+    "sort": "Ordina",
+    "import": "Importa",
+    "aiImport": "Importazione IA",
+    "importWithAI": "Importa con IA",
+    "goHome": "Vai alla home",
+    "test": "Test",
+    "format": "Formato",
+    "restoreDefaults": "Ripristina predefiniti",
+    "saveChanges": "Salva modifiche",
+    "revealSecret": "Mostra segreto",
+    "hideSecret": "Nascondi segreto",
+    "enterNewValue": "Inserisci nuovo valore",
+    "cancelEditing": "Annulla modifica"
+  },
+  "status": {
+    "loading": "Caricamento...",
+    "saving": "Salvataggio...",
+    "deleting": "Eliminazione...",
+    "error": "Errore",
+    "success": "Successo",
+    "noResults": "Nessun risultato trovato",
+    "changing": "Modifica in corso…"
+  },
+  "filters": {
+    "title": "Filtri",
+    "search": "Cerca",
+    "sort": "Ordina",
+    "mode": "Modalità",
+    "modeAll": "Tutti",
+    "modeAny": "Qualsiasi",
+    "tags": "Tag",
+    "searchTags": "Cerca tag",
+    "favoritesAndRating": "Preferiti e valutazione",
+    "favorites": "Preferiti",
+    "cookingTime": "Tempo di cottura",
+    "cookingTimeUnder15": "<15 min",
+    "cookingTimeUnder30": "<30 min",
+    "cookingTimeUnder60": "<60 min",
+    "cookingTimeUnder120": "<120 min",
+    "categories": "Categorie",
+    "category": {
+      "breakfast": "Colazione",
+      "lunch": "Pranzo",
+      "dinner": "Cena",
+      "snack": "Spuntino"
+    },
+    "sortByTitle": "Titolo",
+    "sortByDate": "Data",
+    "clearFilters": "Cancella filtri"
+  },
+  "time": {
+    "minutes": "min",
+    "hours": "ore"
+  },
+  "validation": {
+    "required": "Questo campo è obbligatorio",
+    "invalidUrl": "Inserisci un URL valido"
+  },
+  "errors": {
+    "operationFailed": "Operazione non riuscita",
+    "nameCannotBeEmpty": "Il nome non può essere vuoto",
+    "technicalDetails": "Qualcosa è andato storto. Controlla la console del browser per i dettagli tecnici."
+  },
+  "slots": {
+    "breakfast": "Colazione",
+    "lunch": "Pranzo",
+    "dinner": "Cena",
+    "snack": "Spuntino",
+    "chooseSlot": "Scegli fascia"
+  },
+  "connection": {
+    "connecting": "Connessione a Norish...",
+    "syncing": "Sincronizzazione in corso, attendere...",
+    "checkInternet": "Controlla la tua connessione internet",
+    "gettingUpdates": "Un momento mentre recuperiamo gli ultimi aggiornamenti"
+  },
+  "language": {
+    "title": "Lingua"
+  },
+  "notFound": {
+    "code": "404",
+    "title": "Pagina non trovata",
+    "message": "Ops! Nora non ha trovato quello che stai cercando.\nLa pagina potrebbe essere stata spostata o non esiste."
+  },
+  "import": {
+    "url": {
+      "title": "Importa ricetta",
+      "label": "URL della ricetta",
+      "placeholder": "https://esempio.com/la-tua-ricetta",
+      "failed": "Importazione della ricetta non riuscita",
+      "failedWithAI": "Importazione della ricetta con IA non riuscita"
+    },
+    "paste": {
+      "title": "Importa da testo incollato",
+      "label": "Testo della ricetta o JSON-LD",
+      "placeholder": "Incolla una ricetta (testo libero) o JSON-LD qui...",
+      "characters": "{count} / {max} caratteri",
+      "tooLarge": "Testo troppo lungo",
+      "maxCharacters": "Massimo {max} caratteri consentiti",
+      "importing": "Importazione ricetta...",
+      "importingWithAI": "Importazione ricetta con IA...",
+      "inProgress": "Importazione in corso, attendere...",
+      "failed": "Importazione non riuscita"
+    },
+    "image": {
+      "title": "Importa da immagine",
+      "dropzone": "Trascina le immagini qui o clicca per sfogliare",
+      "paste": "per incollare",
+      "formats": "Supporta JPG, PNG, WebP. Max 10MB per file.",
+      "invalidType": "Tipo di file non valido",
+      "notSupported": "{name} non è un formato immagine supportato",
+      "tooLarge": "File troppo grande",
+      "exceeds": "{name} supera il limite di 10MB",
+      "tooMany": "Troppi file",
+      "maxFiles": "Massimo {max} file consentiti",
+      "importing": "Importazione ricetta dalle immagini...",
+      "analyzing": "Analisi delle immagini in corso, attendere...",
+      "failed": "Importazione non riuscita",
+      "selectedCount": "{count} immagini selezionate - verranno combinate in una ricetta",
+      "library": "Libreria",
+      "takePhoto": "Scatta foto",
+      "counter": "{count} / {max} foto",
+      "importFromCount": "Importa da {count, plural, one {# foto} other {# foto}}"
+    },
+    "menu": {
+      "description": "Importa da un URL, scansiona una foto o parti da zero."
+    }
+  },
+  "formatting": {
+    "title": "Suggerimenti di formattazione",
+    "heading": "Inizia una riga con <strong>#</strong> per un titolo",
+    "bold": "Racchiudi tra <strong>**doppi asterischi**</strong> per il grassetto",
+    "recipeLink": "Digita <strong>/nome ricetta</strong> per collegare un'altra ricetta",
+    "helpAriaLabel": "Aiuto formattazione"
+  },
+  "tagInput": {
+    "placeholder": "Digita i tag separati da spazi..."
+  },
+  "recurrence": {
+    "title": "Ripeti",
+    "frequency": "Frequenza",
+    "interval": "Intervallo",
+    "onDay": "Il giorno",
+    "daily": "Giornaliero",
+    "weekly": "Settimanale",
+    "monthly": "Mensile",
+    "day": "giorno",
+    "days": "giorni",
+    "week": "settimana",
+    "weeks": "settimane",
+    "month": "mese",
+    "months": "mesi",
+    "next": "Prossimo:",
+    "every": "Ogni",
+    "everyOther": "Ogni altro",
+    "on": "il",
+    "today": "oggi",
+    "tomorrow": "domani",
+    "weekdays": {
+      "sun": "Dom",
+      "mon": "Lun",
+      "tue": "Mar",
+      "wed": "Mer",
+      "thu": "Gio",
+      "fri": "Ven",
+      "sat": "Sab"
+    },
+    "weekdaysFull": {
+      "0": "Domenica",
+      "1": "Lunedì",
+      "2": "Martedì",
+      "3": "Mercoledì",
+      "4": "Giovedì",
+      "5": "Venerdì",
+      "6": "Sabato"
+    }
+  },
+  "badges": {
+    "new": "Nuovo"
+  },
+  "timer": {
+    "done": "Finito",
+    "done_action": "Finito",
+    "one": "Timer",
+    "other": "Timer",
+    "label_one": "1 Timer",
+    "label_other": "{count} Timer",
+    "notification_title": "Timer completato",
+    "notification_body": "{label} è pronto!",
+    "notifications_disabled": "Le notifiche sono disabilitate",
+    "notifications_disabled_hint": "Abilita le notifiche nelle impostazioni del browser per ricevere avvisi quando i timer terminano in background."
+  }
+}

--- a/packages/i18n/src/messages/it/groceries.json
+++ b/packages/i18n/src/messages/it/groceries.json
@@ -1,0 +1,78 @@
+{
+  "page": {
+    "title": "Spesa",
+    "addItem": "Aggiungi articolo",
+    "addItems": "Aggiungi articoli",
+    "viewByStore": "Per negozio",
+    "viewByRecipe": "Per ricetta",
+    "viewMode": "Modalità di visualizzazione",
+    "manageStores": "Gestisci negozi",
+    "storeViewOptions": "Opzioni vista negozio",
+    "groupIngredients": "Raggruppa ingredienti"
+  },
+  "empty": {
+    "title": "La tua lista della spesa ti aspetta",
+    "description": "Aggiungi articoli usando il pulsante \"Aggiungi articolo\" sopra per iniziare.",
+    "manual": "Articoli manuali"
+  },
+  "item": {
+    "unnamedItem": "Articolo senza nome",
+    "fromRecipes": "Da {count, plural, one {# ricetta} other {# ricette}}",
+    "items": "{count, plural, one {# articolo} other {# articoli}}"
+  },
+  "store": {
+    "unsorted": "Non ordinati",
+    "noItems": "Nessun articolo in questo negozio",
+    "storeActions": "Azioni negozio",
+    "markAllDone": "Segna tutto come fatto",
+    "deleteDone": "Elimina completati",
+    "done": "{count} completati"
+  },
+  "storeManager": {
+    "title": "Gestisci negozi",
+    "addStore": "Aggiungi negozio",
+    "editStore": "Modifica negozio",
+    "deleteStore": "Elimina negozio",
+    "storeName": "Nome negozio",
+    "storeNamePlaceholder": "es. Supermercato",
+    "storeColor": "Colore",
+    "storeIcon": "Icona",
+    "confirmDelete": "Sei sicuro di voler eliminare {storeName}?",
+    "deleteWarning": "Gli articoli in questo negozio verranno spostati in Non ordinati.",
+    "noStoresYet": "Nessun negozio ancora",
+    "createStoreHint": "Crea un negozio per organizzare la tua spesa",
+    "hasItems": "Questo negozio ha {count} articolo.",
+    "hasItemsPlural": "Questo negozio ha {count} articoli.",
+    "whatToDo": "Cosa vuoi fare con essi?",
+    "keepItems": "Mantieni articoli",
+    "keepItemsDescription": "Sposta gli articoli in Non ordinati",
+    "deleteItems": "Elimina articoli",
+    "deleteItemsDescription": "Rimuovi tutti gli articoli in questo negozio",
+    "noItems": "Questo negozio non ha articoli.",
+    "create": "Crea"
+  },
+  "panel": {
+    "addTitle": "Aggiungi articolo",
+    "editTitle": "Modifica articolo",
+    "itemName": "Nome articolo",
+    "itemNamePlaceholder": "es. Latte, Uova, Pane...",
+    "selectStore": "Seleziona negozio",
+    "noStore": "Nessun negozio",
+    "recurrence": "Ricorrenza",
+    "savePreference": "Ricorda il negozio per questo articolo",
+    "addAnother": "Aggiungi un altro",
+    "addRepeat": "+ Aggiungi ripetizione",
+    "storeOptional": "Negozio (opzionale)",
+    "autoDetectFromHistory": "Rileva automaticamente dalla cronologia",
+    "autoDetectOrSelect": "Rileva automaticamente o seleziona",
+    "placeholder": "es. 1 kg petto di pollo",
+    "editPlaceholder": "es. latte ogni settimana",
+    "servings": "Porzioni",
+    "loadingIngredients": "Caricamento ingredienti...",
+    "noIngredients": "Nessun ingrediente.",
+    "addSelectedToGroceries": "Aggiungi alla spesa",
+    "ingredientsAdded": "Ingredienti aggiunti alla lista della spesa.",
+    "ingredientsFailed": "Aggiunta degli ingredienti alla lista della spesa non riuscita.",
+    "addToGroceries": "Aggiungi alla spesa"
+  }
+}

--- a/packages/i18n/src/messages/it/navbar.json
+++ b/packages/i18n/src/messages/it/navbar.json
@@ -1,0 +1,50 @@
+{
+  "userMenu": {
+    "newRecipe": {
+      "title": "Nuova ricetta",
+      "description": "Scrivi la tua ricetta"
+    },
+    "importUrl": {
+      "title": "Importa da URL",
+      "description": "Incolla un link di una ricetta"
+    },
+    "settings": {
+      "title": "Impostazioni",
+      "description": "Gestisci il tuo account"
+    },
+    "logout": "Esci",
+    "version": {
+      "updateAvailable": "v{version} disponibile"
+    }
+  },
+  "theme": {
+    "title": "Tema",
+    "loading": "Caricamento…",
+    "light": "Modalità chiara",
+    "dark": "Modalità scura",
+    "system": "Predefinito di sistema"
+  },
+  "nav": {
+    "home": "Ricette",
+    "calendar": "Calendario",
+    "groceries": "Spesa"
+  },
+  "mobile": {
+    "searchPlaceholder": "Cerca ricette...",
+    "toggleSearch": "Attiva/disattiva ricerca",
+    "goBack": "Torna indietro"
+  },
+  "archiveImporter": {
+    "uploading": "Caricamento…",
+    "uploadFile": "Carica un file",
+    "dragDrop": "o trascina e rilascia",
+    "formats": ".melarecipes (Mela), .paprikarecipes (Paprika), .zip (Mealie/Tandoor)",
+    "uploadingFile": "Caricamento file…",
+    "processing": "Elaborazione: {details}",
+    "complete": "Completato: {details}",
+    "imported": "{count} importate",
+    "skipped": "{count} saltate",
+    "errors": "{count} errori",
+    "ofTotal": "{current} di {total}"
+  }
+}

--- a/packages/i18n/src/messages/it/recipes.json
+++ b/packages/i18n/src/messages/it/recipes.json
@@ -1,0 +1,223 @@
+{
+  "dashboard": {
+    "title": "Tutte le ricette",
+    "searchPlaceholder": "Cerca o aggiungi ricetta...",
+    "searchRecipesPlaceholder": "Cerca ricette...",
+    "recipeCount": "{count, plural, one {# ricetta} other {# ricette}}",
+    "addRecipe": "Aggiungi ricetta",
+    "importFromUrl": "URL",
+    "importFromPaste": "Incolla",
+    "importFromImage": "Immagine",
+    "searchFields": {
+      "title": "Titolo",
+      "description": "Descrizione",
+      "ingredients": "Ingredienti",
+      "steps": "Passaggi",
+      "tags": "Tag"
+    }
+  },
+  "empty": {
+    "title": "La tua collezione di ricette ti aspetta",
+    "description": "Incolla l'URL di una ricetta nel campo di ricerca sopra e guarda la magia.",
+    "noResults": "Nessuna ricetta trovata",
+    "noResultsHint": "Prova a modificare o cancellare i filtri."
+  },
+  "card": {
+    "noImage": "Nessuna immagine disponibile",
+    "viewGroceries": "Vedi spesa",
+    "addToCalendar": "Aggiungi al calendario",
+    "deleteRecipe": "Elimina ricetta"
+  },
+  "detail": {
+    "backToRecipes": "Torna alle ricette",
+    "viewOriginal": "Vedi ricetta originale",
+    "ingredients": "Ingredienti",
+    "steps": "Passaggi",
+    "notes": "Note",
+    "addToGroceries": "Aggiungi alla spesa",
+    "ratingPrompt": "Cosa ne pensi di questa ricetta?",
+    "notFound": "Ricetta non trovata",
+    "notFoundMessage": "Questa ricetta non esiste o non hai il permesso di visualizzarla.",
+    "prep": "preparazione",
+    "total": "totale",
+    "planMeal": "Pianifica pasto",
+    "recipeActions": "Azioni ricetta",
+    "instructions": "Istruzioni",
+    "cook": "Cucina",
+    "switchToDecimal": "Mostra decimali",
+    "switchToFraction": "Mostra frazioni"
+  },
+  "actions": {
+    "plan": "Pianifica",
+    "groceries": "Spesa",
+    "edit": "Modifica",
+    "delete": "Elimina",
+    "share": "Condividi",
+    "visitOriginal": "Visita ricetta originale",
+    "addToCalendar": "Aggiungi al calendario",
+    "autoTag": "Tag automatici",
+    "autoTagging": "Generazione tag...",
+    "autoCategorize": "Categorizzazione automatica",
+    "detectAllergies": "Rileva allergie",
+    "detectingAllergies": "Rilevamento allergie...",
+    "estimateNutrition": "Stima valori nutrizionali",
+    "estimatingNutrition": "Stima valori nutrizionali...",
+    "screenOn": "Schermo acceso",
+    "keepScreenOn": "Mantieni schermo acceso",
+    "actionsLabel": "Azioni"
+  },
+  "convert": {
+    "ariaLabel": "Converti sistema di misura",
+    "toMetric": "Converti in metrico",
+    "toUS": "Converti in US"
+  },
+  "deleteModal": {
+    "title": "Elimina ricetta",
+    "confirmMessage": "Sei sicuro di voler eliminare \"{recipeName}\"?",
+    "warning": "Questa azione non può essere annullata."
+  },
+  "form": {
+    "createTitle": "Crea ricetta",
+    "editTitle": "Modifica ricetta",
+    "createDescription": "Aggiungi una nuova ricetta alla tua collezione",
+    "editDescription": "Aggiorna i dettagli della tua ricetta",
+    "initializingForm": "Inizializzazione modulo...",
+    "photo": "Foto",
+    "basicInfo": "Informazioni di base",
+    "ingredients": "Ingredienti",
+    "instructions": "Istruzioni",
+    "tags": "Tag",
+    "nutrition": "Valori nutrizionali",
+    "nutritionPerServing": "(per porzione, opzionale)",
+    "details": "Dettagli",
+    "additionalInfo": "Informazioni aggiuntive",
+    "recipeName": "Nome ricetta",
+    "recipeNamePlaceholder": "es. Biscotti con gocce di cioccolato",
+    "description": "Descrizione",
+    "descriptionPlaceholder": "Una breve descrizione di ciò che rende speciale questa ricetta...",
+    "notes": "Note",
+    "notesPlaceholder": "Aggiungi note di preparazione, modifiche o suggerimenti per questa ricetta...",
+    "ingredientsHelp": "Digita gli ingredienti come \"2 tazze di farina\" - analizzeremo automaticamente quantità e unità.",
+    "instructionsHelp": "Scrivi istruzioni chiare passo dopo passo. Premi Invio per passare al passaggio successivo.",
+    "tagsHelp": "Digita i tag e clicca i suggerimenti per aggiungerli. I tag selezionati sono blu, i nuovi tag hanno un bordo tratteggiato.",
+    "tagsAndCategories": "Tag e categorie",
+    "categoriesHelp": "Seleziona le categorie di pasto per questa ricetta.",
+    "category": {
+      "breakfast": "Colazione",
+      "lunch": "Pranzo",
+      "dinner": "Cena",
+      "snack": "Spuntino"
+    },
+    "calories": "Calorie",
+    "fat": "Grassi (g)",
+    "carbs": "Carboidrati (g)",
+    "protein": "Proteine (g)",
+    "servings": "Porzioni",
+    "cookingTimes": "Tempi di cottura",
+    "optional": "(opzionale)",
+    "sourceUrl": "URL di origine",
+    "sourceUrlPlaceholder": "https://esempio.com/ricetta",
+    "measurementSystemNote": "Rileviamo automaticamente il sistema di misura dai tuoi ingredienti, ma puoi sovrascriverlo qui.",
+    "measurementSystemEditNote": " Nota: questo aggiorna l'etichetta del sistema ma non converte le unità. Usa l'azione Converti dopo il salvataggio.",
+    "createRecipe": "Crea ricetta",
+    "saveChanges": "Salva modifiche",
+    "uploading": "Caricamento...",
+    "clickToUpload": "Clicca per caricare o trascina e rilascia",
+    "pasteToUpload": "per incollare",
+    "imageFormats": "PNG, JPG, WEBP fino a 5MB"
+  },
+  "gallery": {
+    "addImage": "Aggiungi immagine",
+    "uploading": "Caricamento...",
+    "uploadFailed": "Caricamento non riuscito",
+    "dragToReorder": "Trascina per riordinare",
+    "maxImagesReached": "Massimo {max} immagini consentite",
+    "maxVideosReached": "Massimo {max} video consentiti",
+    "invalidFileType": "Tipo di file non valido"
+  },
+  "carousel": {
+    "noImageAvailable": "Nessuna immagine disponibile",
+    "noMediaAvailable": "Nessun media disponibile",
+    "videoPlayer": {
+      "mute": "Disattiva audio",
+      "unmute": "Attiva audio",
+      "fullscreen": "Schermo intero",
+      "exitFullscreen": "Esci da schermo intero"
+    }
+  },
+  "validation": {
+    "nameRequired": "Il nome della ricetta è obbligatorio",
+    "ingredientsRequired": "È richiesto almeno un ingrediente",
+    "stepsRequired": "È richiesto almeno un passaggio",
+    "servingsMin": "Le porzioni devono essere almeno 1"
+  },
+  "nutrition": {
+    "title": "Valori nutrizionali",
+    "calories": "Calorie",
+    "fat": "Grassi",
+    "carbs": "Carboidrati",
+    "protein": "Proteine",
+    "showingPortions": "Valori mostrati per {count} {count, plural, one {porzione} other {porzioni}}",
+    "noInfo": "Nessuna informazione nutrizionale disponibile",
+    "estimateWithAI": "Stima con IA"
+  },
+  "measurementSystem": {
+    "label": "Sistema di misura",
+    "detected": "Rilevato: {system}",
+    "metric": "Metrico",
+    "us": "US"
+  },
+  "timeInputs": {
+    "prep": "Preparazione",
+    "cook": "Cottura",
+    "total": "Totale"
+  },
+  "stepInput": {
+    "stepPlaceholder": "Passaggio {number}: Descrivi il passaggio...",
+    "stepPlaceholderShort": "Passaggio {number}"
+  },
+  "ingredientInput": {
+    "placeholder": "es. 2 tazze di farina"
+  },
+  "wakeLock": {
+    "keepScreenOn": "Mantieni schermo acceso",
+    "notSupported": "Mantenere lo schermo acceso non è supportato in questo browser",
+    "activeTooltip": "Lo schermo rimarrà acceso durante la cottura",
+    "inactiveTooltip": "Mantieni lo schermo acceso mentre segui i passaggi",
+    "ariaLabel": "Mantieni schermo acceso"
+  },
+  "toasts": {
+    "processingBoth": "Elaborazione tag e allergie",
+    "processingTags": "Generazione tag",
+    "processingAllergies": "Rilevamento allergie",
+    "bothComplete": "Tag e allergie aggiornati",
+    "tagsComplete": "Tag generati",
+    "allergiesComplete": "Allergie rilevate",
+    "imported": "Ricetta importata",
+    "converted": "Misure convertite",
+    "convertedDescription": "Ricetta convertita in unità {system}",
+    "failed": "Operazione sulla ricetta non riuscita",
+    "failedDescription": "Qualcosa è andato storto durante l'elaborazione della ricetta. Controlla la console del browser per i dettagli tecnici.",
+    "batchImported": "Ricette importate",
+    "batchImportedDescription": "{count} ricette importate dall'archivio",
+    "view": "Visualizza",
+    "open": "Apri"
+  },
+  "tags": {
+    "panel": {
+      "editTitle": "Modifica tag",
+      "editPlaceholder": "Inserisci nome del tag...",
+      "duplicateTag": "Questo tag esiste già"
+    }
+  },
+  "cookMode": {
+    "steps": "Passaggi",
+    "ingredients": "Ingredienti",
+    "servings": "Porzioni",
+    "serving": "{count, plural, one {# porzione} other {# porzioni}}",
+    "stepCounter": "{current} / {total}",
+    "swipeSteps": "Scorri per navigare tra i passaggi",
+    "swipeIngredients": "Scorri a sinistra per gli ingredienti",
+    "swipeBackToSteps": "Scorri a destra per i passaggi"
+  }
+}

--- a/packages/i18n/src/messages/it/settings.json
+++ b/packages/i18n/src/messages/it/settings.json
@@ -1,0 +1,568 @@
+{
+  "page": {
+    "title": "Impostazioni",
+    "loading": "Caricamento...",
+    "ariaLabel": "Schede impostazioni"
+  },
+  "tabs": {
+    "user": "Utente",
+    "household": "Nucleo familiare",
+    "caldav": "CalDAV",
+    "admin": "Amministrazione"
+  },
+  "user": {
+    "profile": {
+      "title": "Profilo",
+      "nameLabel": "Nome",
+      "namePlaceholder": "Il tuo nome",
+      "emailLabel": "Email",
+      "avatarHint": "Clicca sul tuo avatar per cambiare immagine",
+      "deleteAvatar": "Elimina immagine del profilo",
+      "saveChanges": "Salva modifiche"
+    },
+    "allergies": {
+      "title": "Allergie",
+      "description": "Aggiungi le tue allergie alimentari per ricevere avvisi quando pianifichi ricette che contengono allergeni. Queste informazioni vengono utilizzate per avvisarti quando una ricetta pianificata contiene ingredienti che corrispondono alle tue allergie.",
+      "placeholder": "Digita le allergie (es. glutine, frutta a guscio, latticini)...",
+      "saveButton": "Salva allergie"
+    },
+    "apiKeys": {
+      "title": "Chiavi API",
+      "description": "Le chiavi API consentono l'accesso programmatico all'API di Norish. Usale per integrazioni, scorciatoie e automazioni.",
+      "keyNameLabel": "Nome chiave (opzionale)",
+      "keyNamePlaceholder": "es. Scorciatoia iOS",
+      "createKey": "Crea chiave",
+      "yourKeys": "Le tue chiavi API",
+      "noKeys": "Nessuna chiave API ancora. Creane una per iniziare.",
+      "tableHeaders": {
+        "name": "NOME",
+        "keyPrefix": "PREFISSO CHIAVE",
+        "created": "CREATA",
+        "status": "STATO",
+        "actions": "AZIONI"
+      },
+      "unnamed": "Senza nome",
+      "active": "Attiva",
+      "disabled": "Disabilitata",
+      "disableKey": "Disabilita chiave",
+      "enableKey": "Abilita chiave",
+      "deleteKey": "Elimina chiave",
+      "generatedModal": {
+        "title": "Chiave API generata",
+        "warning": "Salva questa chiave ora! Non potrai vederla di nuovo. Conserviamo solo un hash e non possiamo recuperare questa chiave.",
+        "hint": "Usa questa chiave nell'header <code>x-api-key</code> quando effettui richieste API.",
+        "confirmButton": "L'ho salvata"
+      },
+      "deleteModal": {
+        "title": "Elimina chiave API",
+        "message": "Sei sicuro di voler eliminare questa chiave API? Tutte le applicazioni che la utilizzano perderanno immediatamente l'accesso. Questa azione non può essere annullata.",
+        "confirmButton": "Elimina chiave"
+      }
+    },
+    "archiveImport": {
+      "title": "Importa archivio ricette",
+      "description": "Importa ricette da esportazioni Mela (.melarecipes), Paprika (.paprikarecipes) o Mealie/Tandoor (.zip)"
+    },
+    "siteAuthTokens": {
+      "title": "Token di autenticazione siti",
+      "description": "Aggiungi header o cookie inviati durante l'importazione di ricette da siti specifici. Utile per siti che richiedono l'accesso (es. Instagram, Facebook).",
+      "domain": "Dominio",
+      "domainPlaceholder": "es. instagram.com",
+      "name": "Nome",
+      "namePlaceholder": "es. Cookie o Authorization",
+      "value": "Valore",
+      "valuePlaceholder": "Valore del token o cookie",
+      "type": "Tipo",
+      "typeHeader": "Header",
+      "typeCookie": "Cookie",
+      "addButton": "Aggiungi token",
+      "noTokens": "Nessun token di autenticazione siti configurato.",
+      "tableHeaders": {
+        "domain": "DOMINIO",
+        "name": "NOME",
+        "type": "TIPO",
+        "created": "CREATO",
+        "actions": "AZIONI"
+      },
+      "deleteModal": {
+        "title": "Elimina token",
+        "message": "Sei sicuro di voler eliminare questo token di autenticazione? Le importazioni da questo sito potrebbero smettere di funzionare.",
+        "confirmButton": "Elimina token"
+      }
+    },
+    "dangerZone": {
+      "title": "Zona pericolosa",
+      "description": "Una volta eliminato il tuo account, non si può tornare indietro. Assicurati di essere certo.",
+      "deleteButton": "Elimina il mio account",
+      "deleteModal": {
+        "title": "Elimina account",
+        "permanentWarning": "Questa azione è permanente e non può essere annullata!",
+        "dataWarning": "I tuoi dati personali inclusi spesa, voci del calendario e note verranno eliminati permanentemente.",
+        "recipesNote": "Le ricette che hai creato verranno conservate ma non saranno più collegate al tuo account.",
+        "adminNote": "Se sei l'amministratore di un nucleo familiare con altri membri, devi prima trasferire i privilegi di amministratore.",
+        "confirmButton": "Elimina il mio account"
+      }
+    },
+    "preferences": {
+      "title": "Preferenze",
+      "description": "Personalizza la tua esperienza.",
+      "language": {
+        "title": "Lingua",
+        "description": "Scegli la tua lingua preferita"
+      },
+      "timers": {
+        "title": "Abilita timer ricette",
+        "description": "Mostra timer interattivi nelle istruzioni delle ricette"
+      },
+      "conversion": {
+        "title": "Mostra pulsante conversione ingredienti",
+        "description": "Visualizza un pulsante nelle pagine delle ricette per convertire tra sistemi di misura"
+      },
+      "ratings": {
+        "title": "Mostra valutazioni",
+        "description": "Visualizza le valutazioni a stelle sulle schede ricette e nelle pagine di dettaglio"
+      },
+      "favorites": {
+        "title": "Mostra preferiti",
+        "description": "Visualizza le icone preferiti/cuore sulle schede ricette e nelle pagine di dettaglio"
+      },
+      "applyError": "Applicazione della preferenza non riuscita"
+    }
+  },
+  "household": {
+    "pageTitle": "Impostazioni nucleo familiare",
+    "info": {
+      "yourRole": "Il tuo ruolo",
+      "admin": "Amministratore",
+      "member": "Membro",
+      "members": "Membri",
+      "leaveButton": "Lascia nucleo familiare",
+      "leaveModal": {
+        "title": "Lascia nucleo familiare",
+        "confirmMessage": "Sei sicuro di voler lasciare {name}?",
+        "adminWarning": "Sei l'amministratore. Devi trasferire i privilegi di amministratore prima di uscire.",
+        "confirmButton": "Lascia nucleo familiare"
+      }
+    },
+    "members": {
+      "title": "Membri",
+      "tableHeaders": {
+        "name": "NOME",
+        "role": "RUOLO",
+        "actions": "AZIONI"
+      },
+      "you": "Tu",
+      "kickButton": "Espelli",
+      "makeAdminButton": "Rendi amministratore",
+      "kickModal": {
+        "title": "Espelli utente",
+        "confirmMessage": "Sei sicuro di voler espellere {name} dal nucleo familiare?",
+        "warning": "Perderà l'accesso a tutte le ricette, la spesa e le voci del calendario condivise.",
+        "confirmButton": "Espelli utente"
+      },
+      "transferModal": {
+        "title": "Trasferisci privilegi di amministratore",
+        "confirmMessage": "Sei sicuro di voler trasferire i privilegi di amministratore a {name}?",
+        "warning": "Diventerai un membro normale e non potrai più espellere utenti o gestire i codici di accesso.",
+        "confirmButton": "Trasferisci amministratore"
+      },
+      "toasts": {
+        "kickFailed": "Espulsione dell'utente non riuscita",
+        "transferSuccess": "Privilegi di amministratore trasferiti a {name}",
+        "transferFailed": "Trasferimento dei privilegi di amministratore non riuscito"
+      }
+    },
+    "joinCode": {
+      "title": "Codice di accesso",
+      "shareDescription": "Condividi questo codice con altri per invitarli nel tuo nucleo familiare.",
+      "expiresIn": "Scade tra:",
+      "regenerateButton": "Rigenera",
+      "expired": "Scaduto",
+      "noCodeDescription": "Nessun codice di accesso attivo. Generane uno per invitare nuovi membri.",
+      "generateButton": "Genera codice di accesso"
+    },
+    "create": {
+      "title": "Crea nucleo familiare",
+      "description": "Crea un nuovo nucleo familiare per condividere ricette e spesa con famiglia o amici.",
+      "nameLabel": "Nome nucleo familiare",
+      "namePlaceholder": "es. Famiglia Rossi",
+      "submitButton": "Crea nucleo familiare"
+    },
+    "join": {
+      "title": "Unisciti a un nucleo familiare",
+      "description": "Inserisci un codice di accesso per unirti a un nucleo familiare esistente.",
+      "codeLabel": "Codice di accesso",
+      "codePlaceholder": "Codice di 8 caratteri",
+      "submitButton": "Unisciti al nucleo familiare"
+    }
+  },
+  "caldav": {
+    "setup": {
+      "title": "Configura sincronizzazione CalDAV",
+      "description": "Connetti il tuo calendario compatibile CalDAV per sincronizzare automaticamente i tuoi piani pasto",
+      "gettingStarted": "Iniziare con CalDAV",
+      "providerDescription": "Avrai bisogno di un servizio calendario compatibile con CalDAV. I provider più comuni includono:",
+      "serverUrlLabel": "URL del server",
+      "serverUrlDescription": "URL base del tuo server CalDAV (es. https://dav.esempio.com)",
+      "serverUrlPlaceholder": "https://dav.esempio.com",
+      "usernameLabel": "Nome utente",
+      "usernamePlaceholder": "nome utente",
+      "passwordLabel": "Password",
+      "passwordPlaceholder": "Inserisci password",
+      "calendarLabel": "Calendario",
+      "calendarPlaceholder": "Seleziona un calendario",
+      "calendarPlaceholderDisabled": "Testa prima la connessione",
+      "calendarDescription": "Seleziona con quale calendario sincronizzare i piani pasto",
+      "calendarDescriptionDisabled": "Testa la connessione per caricare i calendari disponibili",
+      "timeFormat": "Formato: HH:MM-HH:MM",
+      "timeFormatError": "Il formato deve essere HH:MM-HH:MM",
+      "breakfastTime": "Orario colazione",
+      "lunchTime": "Orario pranzo",
+      "dinnerTime": "Orario cena",
+      "snackTime": "Orario spuntino",
+      "testConnection": "Testa connessione",
+      "saveConfiguration": "Salva configurazione"
+    },
+    "config": {
+      "title": "Configurazione CalDAV",
+      "editTitle": "Modifica configurazione CalDAV",
+      "serverUrl": "URL del server",
+      "enabled": "Abilitato",
+      "disabled": "Disabilitato",
+      "editButton": "Modifica",
+      "deleteButton": "Elimina",
+      "saveChanges": "Salva modifiche",
+      "advancedSettings": "Impostazioni avanzate",
+      "timezone": "Fuso orario: {timezone}",
+      "connectionStatus": {
+        "connected": "Connesso",
+        "checking": "Verifica...",
+        "disconnected": "Disconnesso",
+        "unknown": "Sconosciuto"
+      }
+    },
+    "deleteModal": {
+      "title": "Elimina configurazione CalDAV",
+      "confirmMessage": "Sei sicuro di voler eliminare la tua configurazione CalDAV?",
+      "deleteEventsLabel": "Elimina eventi sincronizzati",
+      "deleteEventsDescription": "Rimuovi tutti gli eventi creati nel tuo calendario CalDAV",
+      "confirmButton": "Elimina"
+    },
+    "syncStatus": {
+      "title": "Stato sincronizzazione",
+      "syncNow": "Sincronizza ora",
+      "clearFilter": "Cancella filtro",
+      "clickToFilter": "Clicca su un badge per filtrare",
+      "showingItems": "Visualizzazione {start}-{end} di {total} elementi",
+      "tableHeaders": {
+        "item": "ELEMENTO",
+        "type": "TIPO",
+        "date": "DATA",
+        "meal": "PASTO",
+        "status": "STATO",
+        "lastSync": "ULTIMA SINCRONIZZAZIONE",
+        "error": "ERRORE"
+      },
+      "statuses": {
+        "synced": "Sincronizzato",
+        "pending": "In attesa",
+        "failed": "Non riuscito",
+        "removed": "Rimosso"
+      },
+      "emptyFiltered": "Nessun elemento {status} trovato",
+      "emptyDefault": "Nessun record di sincronizzazione trovato",
+      "errorDetails": "Dettagli errore"
+    }
+  },
+  "admin": {
+    "general": {
+      "title": "Generale",
+      "allowRegistration": "Consenti registrazione nuovi utenti",
+      "registrationDescription": "Quando disabilitato, solo gli utenti esistenti possono accedere",
+      "locales": "Lingue abilitate",
+      "localesDescription": "Seleziona quali lingue gli utenti possono scegliere",
+      "defaultLocale": "Lingua predefinita",
+      "defaultLocaleDescription": "Lingua utilizzata per i nuovi utenti e come fallback",
+      "saveLocales": "Salva impostazioni lingua",
+      "localesSaved": "Impostazioni lingua salvate",
+      "localesError": "Salvataggio impostazioni lingua non riuscito",
+      "atLeastOneLocale": "Almeno una lingua deve essere abilitata"
+    },
+    "registration": {
+      "title": "Registrazione",
+      "allowRegistration": "Consenti registrazione nuovi utenti",
+      "description": "Quando disabilitato, solo gli utenti esistenti possono accedere"
+    },
+    "permissions": {
+      "title": "Permessi ricette",
+      "description": "Controlla chi può visualizzare, modificare ed eliminare le ricette. Gli amministratori del server hanno sempre accesso completo.",
+      "viewRecipes": "Visualizza ricette",
+      "viewDescription": "Chi può vedere le ricette nella dashboard",
+      "editRecipes": "Modifica ricette",
+      "editDescription": "Chi può modificare i dettagli delle ricette",
+      "deleteRecipes": "Elimina ricette",
+      "deleteDescription": "Chi può rimuovere le ricette",
+      "levels": {
+        "everyone": "Tutti",
+        "everyoneDescription": "Tutti gli utenti autenticati",
+        "household": "Nucleo familiare",
+        "householdDescription": "Il proprietario della ricetta e i membri del suo nucleo familiare",
+        "owner": "Solo proprietario",
+        "ownerDescription": "Solo il proprietario della ricetta"
+      },
+      "note": "Nota: Spesa e voci del calendario seguono automaticamente le regole del nucleo familiare, i membri del nucleo possono sempre modificare/eliminare gli elementi appartenenti a chiunque nello stesso nucleo familiare."
+    },
+    "system": {
+      "title": "Impostazioni di sistema",
+      "cleanup": {
+        "title": "Pulizia programmata",
+        "label": "Mesi di pulizia",
+        "description": "Elimina i pasti pianificati più vecchi di questo numero di mesi"
+      },
+      "server": {
+        "title": "Gestione server",
+        "restartLabel": "Riavvia server",
+        "restartDescription": "Applica le modifiche alla configurazione che richiedono un riavvio",
+        "restartButton": "Riavvia server"
+      }
+    },
+    "restart": {
+      "title": "Riavvia server",
+      "confirmMessage": "Sei sicuro di voler riavviare il server?",
+      "importantTitle": "Importante:",
+      "warning1": "Tutte le connessioni attive verranno disconnesse",
+      "warning2": "Il server non sarà disponibile per alcuni secondi",
+      "warning3": "Assicurati che il tuo deployment abbia <code>restart: always</code> configurato, altrimenti il server non tornerà online automaticamente",
+      "confirmButton": "Riavvia ora"
+    },
+    "authProviders": {
+      "title": "Provider di autenticazione",
+      "requiresRestart": "Richiede riavvio",
+      "description": "Configura i metodi di autenticazione. Le modifiche richiedono un riavvio del server per avere effetto.",
+      "passwordAuth": {
+        "title": "Email e password",
+        "description": "Consenti agli utenti di accedere con email e password"
+      },
+      "oauthDescription": "Configura i provider OAuth per l'autenticazione SSO.",
+      "oidc": {
+        "title": "Provider OIDC",
+        "subtitle": "OpenID Connect generico",
+        "fields": {
+          "name": "Nome provider",
+          "namePlaceholder": "es. Authentik, Keycloak",
+          "issuer": "URL dell'emittente",
+          "issuerPlaceholder": "https://il-tuo-idp.com",
+          "clientId": "Client ID",
+          "clientSecret": "Client Secret",
+          "wellknown": "URL well-known (opzionale)",
+          "wellknownPlaceholder": "Derivato automaticamente dall'emittente se non impostato"
+        },
+        "claimMapping": {
+          "title": "Mappatura claim",
+          "description": "Assegna automaticamente ruoli e nuclei familiari in base ai claim OIDC. Gli utenti con il gruppo admin ottengono i privilegi di amministratore del server. Gli utenti con un gruppo nucleo familiare vengono aggiunti automaticamente a quel nucleo familiare.",
+          "securityWarning": "Attenzione: abilitare la mappatura dei claim consente al tuo identity provider di controllare i privilegi di amministratore e l'appartenenza al nucleo familiare. Abilita questa opzione solo se ti fidi completamente del tuo provider OIDC e hai configurato correttamente i claim dei gruppi.",
+          "scopes": "Scope aggiuntivi",
+          "scopesPlaceholder": "groups, roles",
+          "scopesDescription": "Lista separata da virgole di scope OAuth aggiuntivi da richiedere (es. groups per Keycloak)",
+          "groupsClaim": "Claim gruppi",
+          "groupsClaimDescription": "Nome del claim contenente i gruppi/ruoli dell'utente",
+          "adminGroup": "Gruppo amministratore",
+          "adminGroupDescription": "Nome del gruppo che concede il ruolo di amministratore del server (non sensibile alle maiuscole)",
+          "householdPrefix": "Prefisso nucleo familiare",
+          "householdPrefixDescription": "Prefisso per i nomi dei gruppi nucleo familiare (es. norish_household_famiglia => nucleo familiare 'famiglia')"
+        }
+      },
+      "github": {
+        "title": "GitHub",
+        "subtitle": "GitHub OAuth",
+        "fields": {
+          "clientId": "Client ID",
+          "clientSecret": "Client Secret"
+        }
+      },
+      "google": {
+        "title": "Google",
+        "subtitle": "Google OAuth",
+        "fields": {
+          "clientId": "Client ID",
+          "clientIdPlaceholder": "*.apps.googleusercontent.com",
+          "clientSecret": "Client Secret"
+        }
+      },
+      "form": {
+        "testSuccess": "Connessione riuscita",
+        "removeTitle": "Rimuovi {provider}",
+        "removeConfirm": "Sei sicuro di voler rimuovere questo provider?"
+      },
+      "envBadge": {
+        "db": "Gestito dal DB",
+        "env": "Gestito da env"
+      }
+    },
+    "contentDetection": {
+      "title": "Rilevamento contenuti",
+      "description": "Configura come le ricette vengono rilevate e analizzate dalle pagine web.",
+      "contentIndicators": {
+        "title": "Indicatori di contenuto",
+        "subtitle": "Parole chiave che identificano le pagine di ricette",
+        "description": "Gli indicatori di schema rilevano dati strutturati delle ricette (JSON-LD, microdati). Gli indicatori di contenuto sono parole chiave che suggeriscono che una pagina contiene una ricetta.",
+        "timersEnabled": {
+          "title": "Abilita timer ricette",
+          "description": "Rileva e mostra timer interattivi nelle ricette"
+        }
+      },
+      "units": {
+        "title": "Unità di misura",
+        "subtitle": "Definizioni delle unità di misura per l'analisi",
+        "description": "Definisci le unità di misura con la loro forma abbreviata, plurale e grafie alternative. Utilizzate durante l'analisi delle quantità degli ingredienti."
+      },
+      "recurrence": {
+        "title": "Modelli di ricorrenza",
+        "subtitle": "Modelli in linguaggio naturale per elementi ricorrenti",
+        "description": "Definisci modelli specifici per lingua per l'analisi delle regole di ricorrenza dal linguaggio naturale (es. 'ogni settimana', 'ogni giorno')."
+      },
+      "timerKeywords": {
+        "title": "Parole chiave timer",
+        "subtitle": "Parole chiave delle unità di tempo per il rilevamento dei timer",
+        "description": "Configura le parole chiave utilizzate per rilevare i timer nelle istruzioni delle ricette. Supporta più lingue.",
+        "enableToggle": "Abilita rilevamento timer",
+        "hoursLabel": "Parole chiave ore",
+        "hoursPlaceholder": "ora, ore, h",
+        "hoursHelp": "Parole chiave per le ore (es. ora, ore, h)",
+        "minutesLabel": "Parole chiave minuti",
+        "minutesPlaceholder": "minuto, minuti, min, m",
+        "minutesHelp": "Parole chiave per i minuti (es. minuto, minuti, min)",
+        "secondsLabel": "Parole chiave secondi",
+        "secondsPlaceholder": "secondo, secondi, sec, s",
+        "secondsHelp": "Parole chiave per i secondi (es. secondo, secondi, sec)",
+        "unsavedChanges": "Modifiche non salvate"
+      }
+    },
+    "aiProcessing": {
+      "title": "IA ed elaborazione",
+      "description": "Configura le funzionalità basate sull'IA per l'estrazione delle ricette e l'elaborazione video.",
+      "aiConfig": {
+        "title": "Configurazione IA",
+        "subtitle": "Analisi ed estrazione ricette"
+      },
+      "video": {
+        "title": "Elaborazione video",
+        "subtitle": "Estrazione video social media e trascrizione"
+      },
+      "prompts": {
+        "title": "Prompt",
+        "subtitle": "Personalizza le istruzioni IA per l'elaborazione delle ricette"
+      },
+      "bulkCategorization": {
+        "title": "Categorizzazione in blocco",
+        "subtitle": "Categorizza le ricette non categorizzate usando l'IA",
+        "description": "Metti in coda tutte le ricette non categorizzate per il rilevamento automatico delle categorie tramite IA. Le categorie includono Colazione, Pranzo, Cena e Spuntino.",
+        "button": "Categorizza tutte le ricette",
+        "queued": "{count, plural, =0 {Nessuna ricetta da categorizzare} one {# ricetta in coda} other {# ricette in coda}}",
+        "success": "Categorizzazione avviata",
+        "error": "Avvio della categorizzazione non riuscito"
+      }
+    },
+    "aiConfig": {
+      "enableAI": "Abilita funzionalità IA",
+      "enableAIDescription": "Usa l'IA per estrarre ricette da contenuti non strutturati",
+      "configureWarning": "Configura le impostazioni del provider IA qui sotto per abilitare le funzionalità IA.",
+      "provider": "Provider IA",
+      "providers": {
+        "openai": "OpenAI",
+        "azure": "Azure OpenAI",
+        "anthropic": "Anthropic",
+        "google": "Google AI",
+        "mistral": "Mistral AI",
+        "deepseek": "DeepSeek",
+        "perplexity": "Perplexity",
+        "groq": "Groq",
+        "ollama": "Ollama (Locale)",
+        "lmStudio": "LM Studio (Locale)",
+        "genericOpenai": "Compatibile OpenAI generico"
+      },
+      "endpointUrl": "URL dell'endpoint",
+      "azureEndpoint": "URL risorsa Azure (opzionale)",
+      "azureEndpointDescription": "Endpoint personalizzato Azure OpenAI. Lascia vuoto per il predefinito.",
+      "model": "Modello",
+      "visionModel": "Modello di visione (opzionale)",
+      "visionModelDescription": "Opzionale: usa un modello diverso per compiti di immagine/visione. Lascia vuoto per usare il modello sopra.",
+      "apiKey": "Chiave API",
+      "apiKeyPlaceholder": "Inserisci chiave API",
+      "temperature": "Temperatura: {value}",
+      "temperatureHint": "Più bassa = più focalizzata, Più alta = più creativa",
+      "maxTokens": "Token massimi",
+      "autoTagAllergies": "Rileva automaticamente tag allergie",
+      "autoTagAllergiesDescription": "Aggiungi automaticamente tag relativi alle allergie durante l'importazione delle ricette",
+      "alwaysUseAI": "Usa sempre importazione IA",
+      "alwaysUseAIDescription": "Salta i parser strutturati ed estrai le ricette usando solo l'IA",
+      "autoTaggingMode": "Modalità tag automatici",
+      "autoTaggingModeDescription": "Assegna automaticamente tag/parole chiave alle ricette importate usando l'IA",
+      "autoTaggingModes": {
+        "disabled": "Disabilitato",
+        "predefined": "Solo tag predefiniti",
+        "predefinedDb": "Tag predefiniti + esistenti",
+        "freeform": "L'IA può creare nuovi tag"
+      },
+      "connectionSuccess": "Connessione riuscita",
+      "testConnection": "Testa connessione",
+      "vision": "visione"
+    },
+    "videoConfig": {
+      "enableVideo": "Abilita analisi video",
+      "enableVideoDescription": "Estrai ricette da TikTok, Instagram, YouTube Shorts o Facebook",
+      "configureWarning": "Configura un provider di trascrizione qui sotto per abilitare l'elaborazione video.",
+      "aiDisabledWarning": "Abilita la configurazione IA prima di attivare l'elaborazione video.",
+      "maxLength": "Durata massima video (secondi)",
+      "maxLengthDescription": "I video più lunghi richiedono più tempo e risorse per l'elaborazione",
+      "maxFileSize": "Dimensione massima file video",
+      "maxFileSizeDescription": "Dimensione massima per i file video scaricati",
+      "ytDlpVersion": "Versione yt-dlp",
+      "ytDlpVersionDescription": "Versione di yt-dlp da usare per il download dei video",
+      "transcription": "Trascrizione",
+      "transcriptionDescription": "Converti l'audio del video in testo per l'estrazione delle ricette",
+      "transcriptionProvider": "Provider di trascrizione",
+      "transcriptionProviderDescription": "Solo gli endpoint OpenAI e compatibili con OpenAI supportano la trascrizione Whisper",
+      "transcriptionProviders": {
+        "disabled": "Disabilitato",
+        "openai": "OpenAI Whisper",
+        "groq": "Groq Whisper",
+        "azure": "Azure OpenAI Whisper",
+        "ollama": "Ollama",
+        "genericOpenai": "Compatibile OpenAI generico"
+      },
+      "transcriptionEndpoint": "URL dell'endpoint",
+      "transcriptionEndpointDescription": "Endpoint compatibile OpenAI con supporto Whisper, o endpoint Ollama",
+      "transcriptionModel": "Modello",
+      "transcriptionModelDescription": "Modello Whisper da usare per la trascrizione",
+      "transcriptionModelPlaceholder": "Seleziona o inserisci il nome del modello",
+      "transcriptionApiKey": "Chiave API",
+      "transcriptionApiKeyDescription": "Usa la chiave API della configurazione IA se non impostata",
+      "transcriptionApiKeyPlaceholder": "Lascia vuoto per usare la chiave della configurazione IA",
+      "transcriptionApiKeyOptional": "Chiave API (opzionale)",
+      "transcriptionApiKeyOptionalDescription": "La maggior parte dei server Whisper locali non richiede una chiave API",
+      "transcriptionApiKeyOptionalPlaceholder": "Lascia vuoto per i server locali"
+    },
+    "promptsConfig": {
+      "recipeExtraction": "Prompt estrazione ricette",
+      "recipeExtractionDescription": "Questo prompt viene utilizzato durante l'estrazione dei dati delle ricette da pagine web o trascrizioni video.",
+      "recipeExtractionPlaceholder": "Inserisci il prompt di estrazione ricette...",
+      "unitConversion": "Prompt conversione unità",
+      "unitConversionDescription": "Questo prompt viene utilizzato durante la conversione delle misure delle ricette tra sistemi metrico e US. Variabili disponibili: sourceSystem, targetSystem, units",
+      "unitConversionPlaceholder": "Inserisci il prompt di conversione unità...",
+      "nutritionEstimation": "Prompt stima valori nutrizionali",
+      "nutritionEstimationDescription": "Questo prompt viene utilizzato durante la stima delle informazioni nutrizionali di una ricetta. Variabili disponibili: recipeName, servings, ingredients",
+      "nutritionEstimationPlaceholder": "Inserisci il prompt di stima valori nutrizionali...",
+      "autoTagging": "Prompt tag automatici",
+      "autoTaggingDescription": "Questo prompt viene utilizzato per generare tag per le ricette importate. Definisci le regole di tagging e la lista dei tag predefiniti.",
+      "autoTaggingPlaceholder": "Inserisci il prompt per i tag automatici..."
+    },
+    "unsavedChanges": "Modifiche non salvate",
+    "jsonEditor": {
+      "placeholder": "Inserisci configurazione JSON...",
+      "invalidJson": "Formato JSON non valido",
+      "failedToSave": "Salvataggio non riuscito",
+      "failedToRestore": "Ripristino dei valori predefiniti non riuscito"
+    }
+  }
+}

--- a/packages/shared-server/src/ai/utils/category-matcher.ts
+++ b/packages/shared-server/src/ai/utils/category-matcher.ts
@@ -1,11 +1,12 @@
 import type { IFuseOptions } from "fuse.js";
-import type { RecipeCategory } from "@norish/shared/contracts";
-
 import Fuse from "fuse.js";
+
+import type { RecipeCategory } from "@norish/shared/contracts";
 import deFormalRecipes from "@norish/i18n/messages/de-formal/recipes.json";
 import deInformalRecipes from "@norish/i18n/messages/de-informal/recipes.json";
 import enRecipes from "@norish/i18n/messages/en/recipes.json";
 import frRecipes from "@norish/i18n/messages/fr/recipes.json";
+import itRecipes from "@norish/i18n/messages/it/recipes.json";
 import koRecipes from "@norish/i18n/messages/ko/recipes.json";
 import nlRecipes from "@norish/i18n/messages/nl/recipes.json";
 
@@ -31,6 +32,7 @@ const RECIPES_MESSAGE_BUNDLES: RecipesMessageSubset[] = [
   deFormalRecipes as RecipesMessageSubset,
   deInformalRecipes as RecipesMessageSubset,
   koRecipes as RecipesMessageSubset,
+  itRecipes as RecipesMessageSubset,
 ];
 
 const CATEGORY_MESSAGE_KEYS: Record<RecipeCategory, RecipeCategoryKey> = {


### PR DESCRIPTION
## Description

Add full Italian language support for UI translation strings, recipe category matching, recurrence/scheduling config, unit conversions, and timer keywords.

### Changes
- Add Italian i18n message bundles
- Register locale in server config loader
- Add Italian recurrence config
- Add Italian unit definitions
- Add Italian timer keywords
- Add Italian recipe translations to category matcher

## Related Issue(s)

None

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] Other (please describe):

## Screenshots (if applicable)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

None