### PR TITLE
fix: recipe card delete animation glitching

### DIFF
--- a/apps/web/components/dashboard/recipe-card.tsx
+++ b/apps/web/components/dashboard/recipe-card.tsx
@@ -93,8 +93,6 @@ function RecipeCardComponent({
 
   const handleDeleteClick = useCallback(() => {
     onDeleteModalOpen();
-    // Keep the row open for the delete animation after confirmation
-    setTimeout(() => rowRef.current?.openRow(), 0);
   }, [onDeleteModalOpen]);
 
   const handleDeleteConfirm = useCallback(() => {


### PR DESCRIPTION
## Description

Fix #377 by closing the row on click, but playing the delete animation only after confirmation.

## Related Issue(s)

Fixes #377 

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] Other (please describe):

## Screenshots (if applicable)

## Checklist

<!-- Mark the appropriate options with an "x" -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
