### PR TITLE
fix(calendar): viewport restore on timeline prepend

### DIFF
--- a/apps/web/__tests__/components/calendar/use-prepend-anchor-restore.test.ts
+++ b/apps/web/__tests__/components/calendar/use-prepend-anchor-restore.test.ts
@@ -1,0 +1,123 @@
+import { usePrependAnchorRestore } from "@/components/calendar/use-prepend-anchor-restore";
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+describe("usePrependAnchorRestore", () => {
+  it("is a no-op when restore is called without a pending anchor", () => {
+    const { result } = renderHook(() => usePrependAnchorRestore({ keys: ["2026-01-01"] }));
+
+    const getVirtualItems = vi.fn(() => [{ index: 0, start: 100 }]);
+    const scrollToOffset = vi.fn();
+
+    act(() => {
+      result.current.restoreAnchor(getVirtualItems, scrollToOffset);
+    });
+
+    expect(getVirtualItems).not.toHaveBeenCalled();
+    expect(scrollToOffset).not.toHaveBeenCalled();
+  });
+
+  it("applies normal size-change adjustment when no prepend anchor is pending", () => {
+    const { result } = renderHook(() => usePrependAnchorRestore({ keys: ["2026-01-01"] }));
+
+    expect(result.current.shouldAdjustScrollForSizeChange(100, 150, 0)).toBe(true);
+    expect(result.current.shouldAdjustScrollForSizeChange(200, 150, 0)).toBe(false);
+  });
+
+  it("disables size-change adjustment while prepend anchor is pending", () => {
+    const { result } = renderHook(() => usePrependAnchorRestore({ keys: ["2026-01-01"] }));
+
+    act(() => {
+      result.current.captureAnchor({
+        index: 0,
+        itemStart: 100,
+        scrollOffset: 140,
+      });
+    });
+
+    expect(result.current.shouldAdjustScrollForSizeChange(50, 200, 0)).toBe(false);
+  });
+
+  it("restores scroll offset from captured anchor and clears pending state", () => {
+    const { result } = renderHook(() =>
+      usePrependAnchorRestore({
+        keys: ["2026-01-01", "2026-01-02", "2026-01-03"],
+      })
+    );
+
+    const scrollToOffset = vi.fn();
+
+    act(() => {
+      result.current.captureAnchor({
+        index: 1,
+        itemStart: 300,
+        scrollOffset: 330,
+      });
+    });
+
+    act(() => {
+      result.current.restoreAnchor(
+        () => [
+          { index: 0, start: 100 },
+          { index: 1, start: 500 },
+        ],
+        scrollToOffset
+      );
+    });
+
+    expect(scrollToOffset).toHaveBeenCalledWith(530);
+
+    // Pending state should be cleared after restore.
+    expect(result.current.shouldAdjustScrollForSizeChange(50, 200, 0)).toBe(true);
+  });
+
+  it("clears pending state when target item is not found", () => {
+    const { result } = renderHook(() =>
+      usePrependAnchorRestore({
+        keys: ["2026-01-01", "2026-01-02"],
+      })
+    );
+
+    const scrollToOffset = vi.fn();
+
+    act(() => {
+      result.current.captureAnchor({
+        index: 1,
+        itemStart: 300,
+        scrollOffset: 330,
+      });
+    });
+
+    act(() => {
+      result.current.restoreAnchor(() => [{ index: 0, start: 100 }], scrollToOffset);
+    });
+
+    expect(scrollToOffset).not.toHaveBeenCalled();
+    expect(result.current.shouldAdjustScrollForSizeChange(50, 200, 0)).toBe(true);
+  });
+
+  it("clears pending state when captured key is no longer in keys", () => {
+    const { result, rerender } = renderHook(({ keys }) => usePrependAnchorRestore({ keys }), {
+      initialProps: { keys: ["2026-01-01", "2026-01-02"] },
+    });
+
+    const scrollToOffset = vi.fn();
+
+    act(() => {
+      result.current.captureAnchor({
+        index: 1,
+        itemStart: 300,
+        scrollOffset: 330,
+      });
+    });
+
+    rerender({ keys: ["2026-01-03", "2026-01-04"] });
+
+    act(() => {
+      result.current.restoreAnchor(() => [{ index: 0, start: 100 }], scrollToOffset);
+    });
+
+    expect(scrollToOffset).not.toHaveBeenCalled();
+    expect(result.current.shouldAdjustScrollForSizeChange(50, 200, 0)).toBe(true);
+  });
+});

--- a/apps/web/components/calendar/desktop/desktop-timeline.tsx
+++ b/apps/web/components/calendar/desktop/desktop-timeline.tsx
@@ -16,8 +16,10 @@ import {
 import { useWindowVirtualizer } from "@tanstack/react-virtual";
 import { useLocale, useTranslations } from "next-intl";
 import { useWindowSize } from "usehooks-ts";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { dateKey, eachDayOfInterval } from "@norish/shared/lib/helpers";
+
+import { usePrependAnchorRestore } from "../use-prepend-anchor-restore";
 
 import { DesktopDayCard } from "./desktop-day-card";
 import { DesktopDragOverlay } from "./desktop-drag-overlay";
@@ -96,6 +98,13 @@ export function DesktopTimeline({ onAddItem, onNoteClick, onRecipeClick }: Deskt
 
     return result;
   }, [allDays, columnCount]);
+  const rowKeys = useMemo(
+    () => rows.map((row, index) => (row[0] ? dateKey(row[0]) : `row-${index}`)),
+    [rows]
+  );
+  const { captureAnchor, restoreAnchor, shouldAdjustScrollForSizeChange } = usePrependAnchorRestore(
+    { keys: rowKeys }
+  );
 
   // Date formatters
   const weekdayFormatter = useMemo(
@@ -131,9 +140,15 @@ export function DesktopTimeline({ onAddItem, onNoteClick, onRecipeClick }: Deskt
   // Window virtualizer (like mobile/recipe grid)
   const virtualizer = useWindowVirtualizer({
     count: rows.length,
+    getItemKey: (index) => rowKeys[index] ?? index,
     estimateSize: () => ESTIMATED_ROW_HEIGHT,
     overscan: 2,
     scrollMargin,
+    shouldAdjustScrollPositionOnItemSizeChange: (item, _delta, instance) => {
+      const scrollOffset = instance.scrollOffset ?? 0;
+
+      return shouldAdjustScrollForSizeChange(item.start, scrollOffset, scrollMargin);
+    },
   });
 
   // Track if we've scrolled to today and if we've triggered expand
@@ -193,6 +208,15 @@ export function DesktopTimeline({ onAddItem, onNoteClick, onRecipeClick }: Deskt
 
   const virtualItems = virtualizer.getVirtualItems();
 
+  useLayoutEffect(() => {
+    restoreAnchor(
+      () => virtualizer.getVirtualItems(),
+      (offset) => {
+        virtualizer.scrollToOffset(offset, { behavior: "auto" });
+      }
+    );
+  }, [virtualizer, restoreAnchor]);
+
   // Infinite scroll: trigger expandRange when near the edges
   useEffect(() => {
     if (virtualItems.length === 0 || !hasScrolledRef.current) return;
@@ -206,6 +230,14 @@ export function DesktopTimeline({ onAddItem, onNoteClick, onRecipeClick }: Deskt
     const isNearEnd = lastItem.index >= rows.length - 2;
 
     if (isNearStart && !isLoadingMore && !hasTriggeredExpandPastRef.current) {
+      const scrollOffset = virtualizer.scrollOffset ?? 0;
+
+      captureAnchor({
+        index: firstItem.index,
+        itemStart: firstItem.start,
+        scrollOffset,
+      });
+
       hasTriggeredExpandPastRef.current = true;
       expandRange("past");
     }
@@ -220,7 +252,7 @@ export function DesktopTimeline({ onAddItem, onNoteClick, onRecipeClick }: Deskt
     if (!isNearEnd) {
       hasTriggeredExpandFutureRef.current = false;
     }
-  }, [virtualItems, rows.length, isLoadingMore, expandRange]);
+  }, [virtualItems, rows.length, isLoadingMore, expandRange, virtualizer, captureAnchor]);
 
   const handleScrollToToday = useCallback(() => {
     virtualizer.scrollToIndex(todayRowIndex, { align: "start", behavior: "smooth" });

--- a/apps/web/components/calendar/mobile/mobile-timeline.tsx
+++ b/apps/web/components/calendar/mobile/mobile-timeline.tsx
@@ -18,7 +18,9 @@ import { useWindowVirtualizer } from "@tanstack/react-virtual";
 import { useLocale } from "next-intl";
 import { useWindowSize } from "usehooks-ts";
 import { dateKey, eachDayOfInterval } from "@norish/shared/lib/helpers";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+
+import { usePrependAnchorRestore } from "../use-prepend-anchor-restore";
 
 import { TimelineDaySection } from "./timeline-day-section";
 import { TimelineDragOverlay } from "./timeline-drag-overlay";
@@ -65,6 +67,10 @@ export function MobileTimeline({ onAddItem, onNoteClick, onRecipeClick }: Mobile
     () => eachDayOfInterval(dateRange.start, dateRange.end),
     [dateRange.start, dateRange.end]
   );
+  const dayKeys = useMemo(() => allDays.map((d) => dateKey(d)), [allDays]);
+  const { captureAnchor, restoreAnchor, shouldAdjustScrollForSizeChange } = usePrependAnchorRestore(
+    { keys: dayKeys }
+  );
 
   // Date formatters
   const weekdayFormatter = useMemo(
@@ -108,9 +114,15 @@ export function MobileTimeline({ onAddItem, onNoteClick, onRecipeClick }: Mobile
   // Window virtualizer (like recipe grid)
   const virtualizer = useWindowVirtualizer({
     count: allDays.length,
+    getItemKey: (index) => dayKeys[index] ?? index,
     estimateSize: () => ESTIMATED_DAY_HEIGHT,
     overscan: 5,
     scrollMargin,
+    shouldAdjustScrollPositionOnItemSizeChange: (item, _delta, instance) => {
+      const scrollOffset = instance.scrollOffset ?? 0;
+
+      return shouldAdjustScrollForSizeChange(item.start, scrollOffset, scrollMargin);
+    },
   });
 
   // Track if we've scrolled to today and if we've triggered expand
@@ -183,6 +195,15 @@ export function MobileTimeline({ onAddItem, onNoteClick, onRecipeClick }: Mobile
 
   const virtualItems = virtualizer.getVirtualItems();
 
+  useLayoutEffect(() => {
+    restoreAnchor(
+      () => virtualizer.getVirtualItems(),
+      (offset) => {
+        virtualizer.scrollToOffset(offset, { behavior: "auto" });
+      }
+    );
+  }, [virtualizer, restoreAnchor]);
+
   // Infinite scroll: trigger expandRange when near the edges
   useEffect(() => {
     if (virtualItems.length === 0 || !hasScrolledRef.current) return;
@@ -196,6 +217,14 @@ export function MobileTimeline({ onAddItem, onNoteClick, onRecipeClick }: Mobile
     const isNearEnd = lastItem.index >= allDays.length - 2;
 
     if (isNearStart && !isLoadingMore && !hasTriggeredExpandPastRef.current) {
+      const scrollOffset = virtualizer.scrollOffset ?? 0;
+
+      captureAnchor({
+        index: firstItem.index,
+        itemStart: firstItem.start,
+        scrollOffset,
+      });
+
       hasTriggeredExpandPastRef.current = true;
       expandRange("past");
     }
@@ -210,7 +239,7 @@ export function MobileTimeline({ onAddItem, onNoteClick, onRecipeClick }: Mobile
     if (!isNearEnd) {
       hasTriggeredExpandFutureRef.current = false;
     }
-  }, [virtualItems, allDays.length, isLoadingMore, expandRange]);
+  }, [virtualItems, allDays.length, isLoadingMore, expandRange, virtualizer, captureAnchor]);
 
   const handleScrollToToday = useCallback(() => {
     virtualizer.scrollToIndex(todayIndex, { align: "start", behavior: "smooth" });
@@ -371,6 +400,7 @@ export function MobileTimeline({ onAddItem, onNoteClick, onRecipeClick }: Mobile
                 <div
                   key={virtualItem.key}
                   ref={virtualizer.measureElement}
+                  data-day-key={key}
                   data-index={virtualItem.index}
                   style={{
                     position: "absolute",

--- a/apps/web/components/calendar/use-prepend-anchor-restore.ts
+++ b/apps/web/components/calendar/use-prepend-anchor-restore.ts
@@ -1,0 +1,79 @@
+import { useCallback, useRef } from "react";
+
+type VirtualAnchorItem = {
+  index: number;
+  start: number;
+};
+
+type PendingPrependAnchor = {
+  key: string;
+  offsetWithinItem: number;
+};
+
+type UsePrependAnchorRestoreArgs = {
+  keys: string[];
+};
+
+type CaptureAnchorArgs = {
+  index: number;
+  itemStart: number;
+  scrollOffset: number;
+};
+
+export function usePrependAnchorRestore({ keys }: UsePrependAnchorRestoreArgs) {
+  const pendingPrependAnchorRef = useRef<PendingPrependAnchor | null>(null);
+
+  const captureAnchor = useCallback(
+    ({ index, itemStart, scrollOffset }: CaptureAnchorArgs) => {
+      const key = keys[index];
+
+      if (!key) return;
+
+      pendingPrependAnchorRef.current = {
+        key,
+        offsetWithinItem: scrollOffset - itemStart,
+      };
+    },
+    [keys]
+  );
+
+  const shouldAdjustScrollForSizeChange = useCallback(
+    (itemStart: number, scrollOffset: number, scrollMargin: number) => {
+      if (pendingPrependAnchorRef.current) return false;
+
+      return itemStart < scrollOffset + scrollMargin;
+    },
+    []
+  );
+
+  const restoreAnchor = useCallback(
+    (getVirtualItems: () => VirtualAnchorItem[], scrollToOffset: (offset: number) => void) => {
+      const anchor = pendingPrependAnchorRef.current;
+
+      if (!anchor) return;
+
+      const targetIndex = keys.indexOf(anchor.key);
+
+      if (targetIndex < 0) {
+        pendingPrependAnchorRef.current = null;
+
+        return;
+      }
+
+      const targetItem = getVirtualItems().find((item) => item.index === targetIndex);
+
+      if (targetItem) {
+        scrollToOffset(targetItem.start + anchor.offsetWithinItem);
+      }
+
+      pendingPrependAnchorRef.current = null;
+    },
+    [keys]
+  );
+
+  return {
+    captureAnchor,
+    restoreAnchor,
+    shouldAdjustScrollForSizeChange,
+  };
+}


### PR DESCRIPTION
## Description

Rework calendar virtualization to prevent jumps in the timeline. Use a prepend-anchor approach: capture a stable virtual item key plus intra-item offset before prepending, then restore the viewport in a layout phase using the virtualizer. Gate the virtualizer's auto adjust while a manual restore is pending to avoid flicker.

Please review if this approach is acceptable to resolve the issue. Afaik it's best practice.

## Related Issue(s)

Fixes #387 

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] Other (please describe):

## Checklist

<!-- Mark the appropriate options with an "x" -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

