### PR TITLE
feat: add French localization for various measurement units

### DIFF
--- a/packages/config/src/units.default.json
+++ b/packages/config/src/units.default.json
@@ -20,6 +20,10 @@
       {
         "locale": "da",
         "name": "cl"
+      },
+      {
+        "locale": "fr",
+        "name": "cl"
       }
     ],
     "plural": [
@@ -42,6 +46,10 @@
       {
         "locale": "da",
         "name": "cl"
+      },
+      {
+        "locale": "fr",
+        "name": "centilitres"
       }
     ],
     "alternates": [
@@ -49,7 +57,9 @@
       "centiliters",
       "zentiliter",
       "cl.",
-      "센티리터"
+      "센티리터",
+      "centilitre",
+      "centilitres"
     ]
   },
   "deciliter": {
@@ -73,6 +83,10 @@
       {
         "locale": "da",
         "name": "dl"
+      },
+      {
+        "locale": "fr",
+        "name": "dl"
       }
     ],
     "plural": [
@@ -95,6 +109,10 @@
       {
         "locale": "da",
         "name": "dl"
+      },
+      {
+        "locale": "fr",
+        "name": "décilitres"
       }
     ],
     "alternates": [
@@ -102,7 +120,9 @@
       "deciliters",
       "deziliter",
       "dl.",
-      "데시리터"
+      "데시리터",
+      "décilitre",
+      "décilitres"
     ]
   },
   "gram": {
@@ -126,6 +146,10 @@
       {
         "locale": "da",
         "name": "g"
+      },
+      {
+        "locale": "fr",
+        "name": "g"
       }
     ],
     "plural": [
@@ -148,6 +172,10 @@
       {
         "locale": "da",
         "name": "g"
+      },
+      {
+        "locale": "fr",
+        "name": "grammes"
       }
     ],
     "alternates": [
@@ -159,7 +187,9 @@
       "gramm",
       "grammen",
       "그램",
-      "그람"
+      "그람",
+      "gramme",
+      "grammes"
     ]
   },
   "teaspoon": {
@@ -183,6 +213,10 @@
       {
         "locale": "da",
         "name": "tsk"
+      },
+      {
+        "locale": "fr",
+        "name": "càc"
       }
     ],
     "plural": [
@@ -205,6 +239,10 @@
       {
         "locale": "da",
         "name": "tsk"
+      },
+      {
+        "locale": "fr",
+        "name": "cuillères à café"
       }
     ],
     "alternates": [
@@ -224,7 +262,10 @@
       "t",
       "tsk.",
       "teskefuld",
-      "teskefulde"
+      "teskefulde",
+      "cuillère à café",
+      "cuillères à café",
+      "càc"
     ]
   },
   "tablespoon": {
@@ -248,6 +289,10 @@
       {
         "locale": "da",
         "name": "spsk"
+      },
+      {
+        "locale": "fr",
+        "name": "càs"
       }
     ],
     "plural": [
@@ -270,6 +315,10 @@
       {
         "locale": "da",
         "name": "spsk"
+      },
+      {
+        "locale": "fr",
+        "name": "cuillères à soupe"
       }
     ],
     "alternates": [
@@ -286,7 +335,10 @@
       "T",
       "spsk.",
       "spiseskefuld",
-      "spiseskefulde"
+      "spiseskefulde",
+      "cuillère à soupe",
+      "cuillères à soupe",
+      "càs"
     ]
   },
   "knife_tip": {
@@ -369,6 +421,10 @@
       {
         "locale": "da",
         "name": "nip"
+      },
+      {
+        "locale": "fr",
+        "name": "pincée"
       }
     ],
     "plural": [
@@ -391,6 +447,10 @@
       {
         "locale": "da",
         "name": "nip"
+      },
+      {
+        "locale": "fr",
+        "name": "pincées"
       }
     ],
     "alternates": [
@@ -408,7 +468,9 @@
       "꼬집",
       "약간",
       "et nip",
-      "drys"
+      "drys",
+      "pincée",
+      "pincées"
     ]
   },
   "piece": {
@@ -558,6 +620,10 @@
       {
         "locale": "da",
         "name": "blad"
+      },
+      {
+        "locale": "fr",
+        "name": "feuille"
       }
     ],
     "plural": [
@@ -580,6 +646,10 @@
       {
         "locale": "da",
         "name": "blade"
+      },
+      {
+        "locale": "fr",
+        "name": "feuilles"
       }
     ],
     "alternates": [
@@ -590,7 +660,9 @@
       "leaf",
       "leaves",
       "잎",
-      "장"
+      "장",
+      "feuille",
+      "feuilles"
     ]
   },
   "sprig": {
@@ -793,6 +865,10 @@
       {
         "locale": "da",
         "name": "pakke"
+      },
+      {
+        "locale": "fr",
+        "name": "paquet"
       }
     ],
     "plural": [
@@ -815,6 +891,10 @@
       {
         "locale": "da",
         "name": "pakker"
+      },
+      {
+        "locale": "fr",
+        "name": "paquets"
       }
     ],
     "alternates": [
@@ -838,7 +918,9 @@
       "봉",
       "봉지",
       "포",
-      "pk."
+      "pk.",
+      "paquet",
+      "paquets"
     ]
   },
   "can": {
@@ -989,6 +1071,10 @@
       {
         "locale": "da",
         "name": "fl."
+      },
+      {
+        "locale": "fr",
+        "name": "bouteille"
       }
     ],
     "plural": [
@@ -1011,6 +1097,10 @@
       {
         "locale": "da",
         "name": "flasker"
+      },
+      {
+        "locale": "fr",
+        "name": "bouteilles"
       }
     ],
     "alternates": [
@@ -1027,7 +1117,9 @@
       "flesjes",
       "flessen",
       "fläschchen",
-      "병"
+      "병",
+      "bouteille",
+      "bouteilles"
     ]
   },
   "bag": {
@@ -1114,6 +1206,10 @@
       {
         "locale": "da",
         "name": "æske"
+      },
+      {
+        "locale": "fr",
+        "name": "boîte"
       }
     ],
     "plural": [
@@ -1136,6 +1232,10 @@
       {
         "locale": "da",
         "name": "æsker"
+      },
+      {
+        "locale": "fr",
+        "name": "boîtes"
       }
     ],
     "alternates": [
@@ -1147,7 +1247,9 @@
       "doosjes",
       "dozen",
       "박스",
-      "상자"
+      "상자",
+      "boîte",
+      "boîtes"
     ]
   },
   "handful": {
@@ -1292,6 +1394,10 @@
       {
         "locale": "da",
         "name": "kop"
+      },
+      {
+        "locale": "fr",
+        "name": "tasse"
       }
     ],
     "plural": [
@@ -1314,6 +1420,10 @@
       {
         "locale": "da",
         "name": "kopper"
+      },
+      {
+        "locale": "fr",
+        "name": "tasses"
       }
     ],
     "alternates": [
@@ -1336,7 +1446,9 @@
       "tässchen",
       "컵",
       "공기",
-      "pægl"
+      "pægl",
+      "tasse",
+      "tasses"
     ]
   },
   "glass": {
@@ -1360,6 +1472,10 @@
       {
         "locale": "da",
         "name": "glas"
+      },
+      {
+        "locale": "fr",
+        "name": "verre"
       }
     ],
     "plural": [
@@ -1382,6 +1498,10 @@
       {
         "locale": "da",
         "name": "glas"
+      },
+      {
+        "locale": "fr",
+        "name": "verres"
       }
     ],
     "alternates": [
@@ -1394,7 +1514,9 @@
       "kleines glas",
       "shotglas",
       "잔",
-      "컵"
+      "컵",
+      "verre",
+      "verres"
     ]
   },
   "slice": {
@@ -1418,6 +1540,10 @@
       {
         "locale": "da",
         "name": "skive"
+      },
+      {
+        "locale": "fr",
+        "name": "tranche"
       }
     ],
     "plural": [
@@ -1440,6 +1566,10 @@
       {
         "locale": "da",
         "name": "skiver"
+      },
+      {
+        "locale": "fr",
+        "name": "tranches"
       }
     ],
     "alternates": [
@@ -1454,7 +1584,9 @@
       "slice",
       "slices",
       "조각",
-      "슬라이스"
+      "슬라이스",
+      "tranche",
+      "tranches"
     ]
   },
   "strip": {
@@ -1533,6 +1665,10 @@
       {
         "locale": "da",
         "name": "ark"
+      },
+      {
+        "locale": "fr",
+        "name": "feuille"
       }
     ],
     "plural": [
@@ -1555,6 +1691,10 @@
       {
         "locale": "da",
         "name": "ark"
+      },
+      {
+        "locale": "fr",
+        "name": "feuilles"
       }
     ],
     "alternates": [
@@ -1562,7 +1702,9 @@
       "vellen",
       "velletje",
       "velletjes",
-      "장"
+      "장",
+      "feuille",
+      "feuilles"
     ]
   },
   "serving": {
@@ -3514,6 +3656,10 @@
       {
         "locale": "da",
         "name": "ml"
+      },
+      {
+        "locale": "fr",
+        "name": "ml"
       }
     ],
     "plural": [
@@ -3536,6 +3682,10 @@
       {
         "locale": "da",
         "name": "milliliter"
+      },
+      {
+        "locale": "fr",
+        "name": "millilitres"
       }
     ],
     "alternates": [
@@ -3546,7 +3696,9 @@
       "ml",
       "ml.",
       "밀리리터",
-      "밀리"
+      "밀리",
+      "millilitre",
+      "millilitres"
     ]
   },
   "liter": {
@@ -3570,6 +3722,10 @@
       {
         "locale": "da",
         "name": "l"
+      },
+      {
+        "locale": "fr",
+        "name": "l"
       }
     ],
     "plural": [
@@ -3592,6 +3748,10 @@
       {
         "locale": "da",
         "name": "liter"
+      },
+      {
+        "locale": "fr",
+        "name": "litres"
       }
     ],
     "alternates": [
@@ -3602,7 +3762,9 @@
       "l",
       "l.",
       "L",
-      "리터"
+      "리터",
+      "litre",
+      "litres"
     ]
   },
   "centimeter": {
@@ -3626,6 +3788,10 @@
       {
         "locale": "da",
         "name": "cm"
+      },
+      {
+        "locale": "fr",
+        "name": "cm"
       }
     ],
     "plural": [
@@ -3648,6 +3814,10 @@
       {
         "locale": "da",
         "name": "cm"
+      },
+      {
+        "locale": "fr",
+        "name": "centimètres"
       }
     ],
     "alternates": [
@@ -3656,7 +3826,9 @@
       "zentimeter",
       "cm.",
       "센치",
-      "센치미터"
+      "센치미터",
+      "centimètre",
+      "centimètres"
     ]
   }
 }


### PR DESCRIPTION
## Description

This PR introduces French locale support for measurement units in the configuration package, enhancing internationalization for French-speaking users.

> ⚠️ **Important Note**
> This is not a 100% complete translation, but rather a preliminary pass focusing on the most commonly used measurement units.
> Further refinements may be needed in future updates.
> 

## Related Issue(s)

None

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [X] Other (please describe): i18n/l10n

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [X] Manual testing
- [ ] Other (please describe):

## Screenshots (if applicable)

<img width="477" height="595" alt="Capture d’écran 2026-03-26 à 21 30 21" src="https://github.com/user-attachments/assets/81b1ec15-9857-4952-aad4-898f86b9138f" />

## Checklist

<!-- Mark the appropriate options with an "x" -->

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

<!-- Add any other context about the PR here -->
