### PR TITLE
Streamline dev setup with pnpm run devsetup

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,8 +355,10 @@ cd norish
 # Install dependencies
 pnpm install
 
-# Create your environment file
-cp .env.example .env.local
+# Run devsetup
+# This copies .env.example to .env.local if it doesn't exist yet
+# Then generates a new master key for encryption and adds it to the env file if it's not defined yet.
+pnpm run devsetup
 
 # Start required services (Postgres, Redis, Chrome)
 pnpm run docker:up
@@ -370,21 +372,22 @@ pnpm run dev:mobile
 
 ### Development Commands
 
-| Command                  | Description                                               |
-| ------------------------ | --------------------------------------------------------- |
-| `pnpm run dev`           | Start development server with hot reload                  |
-| `pnpm run dev:mobile`    | Start Expo mobile workspace (`apps/mobile`)               |
-| `pnpm run build:web`     | Build Next.js app workspace (`apps/web`)                  |
-| `pnpm run build`         | Full production build (Next.js + server + service worker) |
-| `pnpm run test`          | Run tests via Turbo across all workspaces                 |
-| `pnpm run test:run`      | Run tests once via Turbo                                  |
-| `pnpm run test:coverage` | Run tests with coverage report                            |
-| `pnpm run lint`          | Check for linting errors across all workspaces            |
-| `pnpm run lint:check`    | Lint all workspaces and run monorepo integrity checks     |
-| `pnpm run format`        | Check formatting across all workspaces (no auto-fix)      |
-| `pnpm run typecheck`     | Run type checking across all workspaces                   |
-| `pnpm run docker:up`     | Start local dependency stack via Compose                  |
-| `pnpm run docker:down`   | Stop local dependency stack                               |
+| Command                  | Description                                                          |
+| ------------------------ | -------------------------------------------------------------------- |
+| `pnpm run devsetup`      | Create `.env.local` if missing and generate `MASTER_KEY` if missing  |
+| `pnpm run dev`           | Start development server with hot reload                             |
+| `pnpm run dev:mobile`    | Start Expo mobile workspace (`apps/mobile`)                          |
+| `pnpm run build:web`     | Build Next.js app workspace (`apps/web`)                             |
+| `pnpm run build`         | Full production build (Next.js + server + service worker)            |
+| `pnpm run test`          | Run tests via Turbo across all workspaces                            |
+| `pnpm run test:run`      | Run tests once via Turbo                                             |
+| `pnpm run test:coverage` | Run tests with coverage report                                       |
+| `pnpm run lint`          | Check for linting errors across all workspaces                       |
+| `pnpm run lint:check`    | Lint all workspaces and run monorepo integrity checks                |
+| `pnpm run format`        | Check formatting across all workspaces (no auto-fix)                 |
+| `pnpm run typecheck`     | Run type checking across all workspaces                              |
+| `pnpm run docker:up`     | Start local dependency stack via Compose                             |
+| `pnpm run docker:down`   | Stop local dependency stack                                          |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "type": "module",
   "packageManager": "pnpm@10.30.1",
   "scripts": {
+    "devsetup": "pnpm run devsetup:copyenvfile && pnpm run devsetup:createmasterkey",
+    "devsetup:copyenvfile": "node -e \"const fs=require('fs');if(!fs.existsSync('.env.local'))fs.copyFileSync('.env.example','.env.local')\"",
+    "devsetup:createmasterkey": "node -e \"const fs=require('fs'),crypto=require('crypto'),f='.env.local';fs.writeFileSync(f,fs.readFileSync(f,'utf8').replace('<32-byte-base64-key>',crypto.randomBytes(32).toString('base64')))\"",
     "dev": "turbo watch dev -F @norish/web... --continue",
     "dev:mobile": "pnpm --filter @norish/mobile run start",
     "build:web": "pnpm --filter @norish/web run build:web",


### PR DESCRIPTION
## Description

Introduces a new `devsetup` command to automate initial environment configuration. This command now handles two key steps:
- Copies `.env.example` to `.env.local` only if the latter does not exist, preventing accidental overwrites.
- Generates a unique `MASTER_KEY` for encryption and replaces the placeholder in `.env.local` if it's still there. It does not replace the key if there is already one.

This enhancement simplifies the onboarding process for new developers and ensures a consistent setup, reducing manual steps and potential configuration errors.

## Related Issue(s)

<!-- Link to the related issue(s) this PR addresses -->

Fixes #

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] Other (please describe):

## Screenshots (if applicable)

## Checklist

<!-- Mark the appropriate options with an "x" -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

Small change, but it establishes a single setup entry point and should scale better than documenting separate manual steps as setup grows.
