### PR TITLE
Add proxy support for yt-dlp

### DIFF
--- a/apps/web/app/(app)/settings/admin/components/video-processing-form.tsx
+++ b/apps/web/app/(app)/settings/admin/components/video-processing-form.tsx
@@ -53,6 +53,7 @@ export default function VideoProcessingForm({ onDirtyChange }: VideoProcessingFo
     videoConfig ? Math.round(videoConfig.maxVideoFileSize / (1024 * 1024)) : 100
   );
   const [ytDlpVersion, setYtDlpVersion] = useState(videoConfig?.ytDlpVersion ?? "2025.11.12");
+  const [ytDlpProxy, setYtDlpProxy] = useState(videoConfig?.ytDlpProxy ?? "");
   const [transcriptionProvider, setTranscriptionProvider] = useState<TranscriptionProvider>(
     videoConfig?.transcriptionProvider ?? "disabled"
   );
@@ -72,6 +73,7 @@ export default function VideoProcessingForm({ onDirtyChange }: VideoProcessingFo
       setMaxLengthSeconds(videoConfig.maxLengthSeconds);
       setMaxVideoFileSizeMB(Math.round(videoConfig.maxVideoFileSize / (1024 * 1024)));
       setYtDlpVersion(videoConfig.ytDlpVersion);
+      setYtDlpProxy(videoConfig.ytDlpProxy ?? "");
       setTranscriptionProvider(videoConfig.transcriptionProvider);
       setTranscriptionEndpoint(videoConfig.transcriptionEndpoint ?? "");
       setTranscriptionModel(videoConfig.transcriptionModel);
@@ -187,6 +189,7 @@ export default function VideoProcessingForm({ onDirtyChange }: VideoProcessingFo
       maxLengthSeconds !== videoConfig.maxLengthSeconds ||
       maxVideoFileSizeMB !== Math.round(videoConfig.maxVideoFileSize / (1024 * 1024)) ||
       ytDlpVersion !== videoConfig.ytDlpVersion ||
+      ytDlpProxy !== (videoConfig.ytDlpProxy ?? "") ||
       transcriptionProvider !== videoConfig.transcriptionProvider ||
       transcriptionEndpoint !== (videoConfig.transcriptionEndpoint ?? "") ||
       transcriptionModel !== videoConfig.transcriptionModel ||
@@ -198,6 +201,7 @@ export default function VideoProcessingForm({ onDirtyChange }: VideoProcessingFo
     maxLengthSeconds,
     maxVideoFileSizeMB,
     ytDlpVersion,
+    ytDlpProxy,
     transcriptionProvider,
     transcriptionEndpoint,
     transcriptionModel,
@@ -222,6 +226,7 @@ export default function VideoProcessingForm({ onDirtyChange }: VideoProcessingFo
         maxLengthSeconds,
         maxVideoFileSize: maxVideoFileSizeMB * 1024 * 1024, // Convert MB to bytes
         ytDlpVersion,
+        ytDlpProxy: ytDlpProxy || undefined,
         transcriptionProvider,
         transcriptionEndpoint: transcriptionEndpoint || undefined,
         transcriptionApiKey: transcriptionApiKey || undefined,
@@ -286,6 +291,15 @@ export default function VideoProcessingForm({ onDirtyChange }: VideoProcessingFo
         label={t("ytDlpVersion")}
         value={ytDlpVersion}
         onValueChange={setYtDlpVersion}
+      />
+
+      <Input
+        description={t("ytDlpProxyDescription")}
+        isDisabled={isVideoUiDisabled}
+        label={t("ytDlpProxy")}
+        placeholder="socks5://127.0.0.1:1080"
+        value={ytDlpProxy}
+        onValueChange={setYtDlpProxy}
       />
 
       <Divider className="my-2" />

--- a/packages/api/src/startup/seed-config.ts
+++ b/packages/api/src/startup/seed-config.ts
@@ -120,6 +120,7 @@ const REQUIRED_CONFIGS: ConfigDefinition[] = [
       maxLengthSeconds: SERVER_CONFIG.VIDEO_MAX_LENGTH_SECONDS,
       maxVideoFileSize: SERVER_CONFIG.MAX_VIDEO_FILE_SIZE,
       ytDlpVersion: SERVER_CONFIG.YT_DLP_VERSION,
+      ytDlpProxy: SERVER_CONFIG.YT_DLP_PROXY || undefined,
       transcriptionProvider: SERVER_CONFIG.TRANSCRIPTION_PROVIDER,
       transcriptionEndpoint: SERVER_CONFIG.TRANSCRIPTION_ENDPOINT || undefined,
       transcriptionApiKey: SERVER_CONFIG.TRANSCRIPTION_API_KEY || undefined,

--- a/packages/api/src/video/yt-dlp.ts
+++ b/packages/api/src/video/yt-dlp.ts
@@ -110,7 +110,13 @@ export const DOWNLOAD_VIDEO_FORMAT_SELECTOR =
 // In development, download to the configured runtime bin directory on first use
 const ytDlpPath = path.resolve(SERVER_CONFIG.YT_DLP_BIN_DIR, ytDlpFilename);
 const outputDir = path.join(SERVER_CONFIG.UPLOADS_DIR, "video-temp");
-const proxyArgs = SERVER_CONFIG.YT_DLP_PROXY ? ["--proxy", SERVER_CONFIG.YT_DLP_PROXY] : [];
+
+async function getProxyArgs(): Promise<string[]> {
+  const videoConfig = await getVideoConfig();
+  const proxy = videoConfig?.ytDlpProxy || SERVER_CONFIG.YT_DLP_PROXY;
+
+  return proxy ? ["--proxy", proxy] : [];
+}
 
 export async function ensureYtDlpBinary(): Promise<void> {
   log.debug({ ytDlpPath }, "Checking for binary");
@@ -239,6 +245,7 @@ export async function getVideoMetadata(
 
 
   try {
+    const proxyArgs = await getProxyArgs();
     const rawInfo = await ytDlpWrap.getVideoInfo([url, ...(auth?.args ?? []), ...proxyArgs]);
 
     // yt-dlp returns an array for Instagram carousel/image posts (one entry per image)
@@ -298,6 +305,7 @@ export async function downloadVideoAudio(
     const ffmpegDir = ffmpegBinary ? path.dirname(ffmpegBinary) : undefined;
 
     log.debug({ ffmpegDir, ffmpegBinary }, "Using ffmpeg for audio extraction");
+    const proxyArgs = await getProxyArgs();
 
     const args = [
       url,
@@ -425,7 +433,7 @@ export async function downloadCaptions(
       "--extractor-args",
       "youtube:player_client=default",
       ...(auth?.args ?? []),
-      ...proxyArgs,
+      ...(await getProxyArgs()),
     ];
 
     await ytDlpWrap.execPromise(args);
@@ -559,7 +567,7 @@ export async function downloadVideo(
       "--extractor-args",
       "youtube:player_client=default",
       ...(auth?.args ?? []),
-      ...proxyArgs,
+      ...(await getProxyArgs()),
     ];
 
     // Add ffmpeg location if available

--- a/packages/api/src/video/yt-dlp.ts
+++ b/packages/api/src/video/yt-dlp.ts
@@ -110,6 +110,7 @@ export const DOWNLOAD_VIDEO_FORMAT_SELECTOR =
 // In development, download to the configured runtime bin directory on first use
 const ytDlpPath = path.resolve(SERVER_CONFIG.YT_DLP_BIN_DIR, ytDlpFilename);
 const outputDir = path.join(SERVER_CONFIG.UPLOADS_DIR, "video-temp");
+const proxyArgs = SERVER_CONFIG.YT_DLP_PROXY ? ["--proxy", SERVER_CONFIG.YT_DLP_PROXY] : [];
 
 export async function ensureYtDlpBinary(): Promise<void> {
   log.debug({ ytDlpPath }, "Checking for binary");
@@ -236,10 +237,9 @@ export async function getVideoMetadata(
 
   const auth = tokens?.length ? await buildAuthArgs(tokens, url) : null;
 
+
   try {
-    const rawInfo = auth
-      ? await ytDlpWrap.getVideoInfo([url, ...auth.args])
-      : await ytDlpWrap.getVideoInfo(url);
+    const rawInfo = await ytDlpWrap.getVideoInfo([url, ...(auth?.args ?? []), ...proxyArgs]);
 
     // yt-dlp returns an array for Instagram carousel/image posts (one entry per image)
     // For single videos, it returns an object directly
@@ -291,6 +291,7 @@ export async function downloadVideoAudio(
 
   const auth = tokens?.length ? await buildAuthArgs(tokens, url) : null;
 
+
   try {
     // Download video and extract audio as WAV format
     const ffmpegBinary = getFfmpegPath();
@@ -310,6 +311,7 @@ export async function downloadVideoAudio(
       "--extractor-args",
       "youtube:player_client=default", // Suppress JS runtime warning
       ...(auth?.args ?? []),
+      ...proxyArgs,
     ];
 
     // Add ffmpeg location if available
@@ -404,6 +406,7 @@ export async function downloadCaptions(
 
   const auth = tokens?.length ? await buildAuthArgs(tokens, url) : null;
 
+
   const resolvedSubLang = subLang ?? "en";
 
   log.debug({ subLang, resolvedSubLang, url }, "Using language for subtitle download");
@@ -422,6 +425,7 @@ export async function downloadCaptions(
       "--extractor-args",
       "youtube:player_client=default",
       ...(auth?.args ?? []),
+      ...proxyArgs,
     ];
 
     await ytDlpWrap.execPromise(args);
@@ -538,6 +542,7 @@ export async function downloadVideo(
 
   const auth = tokens?.length ? await buildAuthArgs(tokens, url) : null;
 
+
   try {
     const ffmpegBinary = getFfmpegPath();
     const ffmpegDir = ffmpegBinary ? path.dirname(ffmpegBinary) : undefined;
@@ -554,6 +559,7 @@ export async function downloadVideo(
       "--extractor-args",
       "youtube:player_client=default",
       ...(auth?.args ?? []),
+      ...proxyArgs,
     ];
 
     // Add ffmpeg location if available

--- a/packages/config/src/env-config-server.ts
+++ b/packages/config/src/env-config-server.ts
@@ -172,6 +172,7 @@ const ServerConfigSchema = z.object({
     .pipe(z.boolean())
     .default(false),
   VIDEO_MAX_LENGTH_SECONDS: z.coerce.number().default(120),
+  YT_DLP_PROXY: z.string().optional(),
   YT_DLP_VERSION: z.string().default("2025.11.12"),
   YT_DLP_BIN_DIR: z.string().default(defaultYtDlpBinDir),
 

--- a/packages/config/src/zod/server-config.ts
+++ b/packages/config/src/zod/server-config.ts
@@ -324,6 +324,7 @@ export const VideoConfigSchema = z.object({
   maxLengthSeconds: z.number().int().positive(),
   maxVideoFileSize: z.number().int().positive(), // Max video file size in bytes
   ytDlpVersion: z.string().min(1),
+  ytDlpProxy: z.string().optional(),
   // Transcription settings (required for video processing)
   transcriptionProvider: TranscriptionProviderSchema,
   transcriptionEndpoint: z.url("Endpoint must be a valid URL").optional(),

--- a/packages/i18n/src/messages/da/settings.json
+++ b/packages/i18n/src/messages/da/settings.json
@@ -519,6 +519,8 @@
       "maxFileSizeDescription": "Maksimal størrelse for downloadede videofiler",
       "ytDlpVersion": "yt-dlp-version",
       "ytDlpVersionDescription": "Version af yt-dlp til brug ved videodownloads",
+      "ytDlpProxy": "yt-dlp Proxy",
+      "ytDlpProxyDescription": "HTTP/SOCKS5-proxy til yt-dlp",
       "transcription": "Transskription",
       "transcriptionDescription": "Konverter videoens lyd til tekst til opskriftudtrækning",
       "transcriptionProvider": "Transskriptionsudbyder",

--- a/packages/i18n/src/messages/de-formal/settings.json
+++ b/packages/i18n/src/messages/de-formal/settings.json
@@ -519,6 +519,8 @@
       "maxFileSizeDescription": "Maximale Größe für heruntergeladene Videodateien",
       "ytDlpVersion": "yt-dlp-Version",
       "ytDlpVersionDescription": "Version von yt-dlp zum Verwenden für Video-Downloads",
+      "ytDlpProxy": "yt-dlp Proxy",
+      "ytDlpProxyDescription": "HTTP/SOCKS5-Proxy für yt-dlp",
       "transcription": "Transkription",
       "transcriptionDescription": "Konvertiere Video-Audio zu Text für Rezept-Extraktion",
       "transcriptionProvider": "Transkriptions-Anbieter",

--- a/packages/i18n/src/messages/de-informal/settings.json
+++ b/packages/i18n/src/messages/de-informal/settings.json
@@ -519,6 +519,8 @@
       "maxFileSizeDescription": "Maximale Größe für heruntergeladene Videodateien",
       "ytDlpVersion": "yt-dlp-Version",
       "ytDlpVersionDescription": "Version von yt-dlp zum Verwenden für Video-Downloads",
+      "ytDlpProxy": "yt-dlp Proxy",
+      "ytDlpProxyDescription": "HTTP/SOCKS5-Proxy für yt-dlp",
       "transcription": "Transkription",
       "transcriptionDescription": "Konvertiere Video-Audio zu Text für Rezept-Extraktion",
       "transcriptionProvider": "Transkriptions-Anbieter",

--- a/packages/i18n/src/messages/en/settings.json
+++ b/packages/i18n/src/messages/en/settings.json
@@ -519,6 +519,8 @@
       "maxFileSizeDescription": "Maximum size for downloaded video files",
       "ytDlpVersion": "yt-dlp Version",
       "ytDlpVersionDescription": "Version of yt-dlp to use for video downloads",
+      "ytDlpProxy": "yt-dlp Proxy",
+      "ytDlpProxyDescription": "HTTP/SOCKS5 proxy for yt-dlp",
       "transcription": "Transcription",
       "transcriptionDescription": "Convert video audio to text for recipe extraction",
       "transcriptionProvider": "Transcription Provider",

--- a/packages/i18n/src/messages/es/settings.json
+++ b/packages/i18n/src/messages/es/settings.json
@@ -519,6 +519,8 @@
       "maxFileSizeDescription": "Tamaño máximo para archivos de vídeo descargados",
       "ytDlpVersion": "Versión de yt-dlp",
       "ytDlpVersionDescription": "Versión de yt-dlp a usar para descargas de vídeo",
+      "ytDlpProxy": "yt-dlp Proxy",
+      "ytDlpProxyDescription": "Proxy HTTP/SOCKS5 para yt-dlp",
       "transcription": "Transcripción",
       "transcriptionDescription": "Convertir el audio del vídeo a texto para extraer la receta",
       "transcriptionProvider": "Proveedor de transcripción",

--- a/packages/i18n/src/messages/fr/settings.json
+++ b/packages/i18n/src/messages/fr/settings.json
@@ -519,6 +519,8 @@
       "maxFileSizeDescription": "Taille maximale des fichiers vidéo téléchargés",
       "ytDlpVersion": "Version de yt-dlp",
       "ytDlpVersionDescription": "Version utilisée pour les téléchargements vidéo",
+      "ytDlpProxy": "yt-dlp Proxy",
+      "ytDlpProxyDescription": "Proxy HTTP/SOCKS5 pour yt-dlp",
       "transcription": "Transcription",
       "transcriptionDescription": "Convertit l’audio en texte pour extraire les recettes",
       "transcriptionProvider": "Fournisseur de transcription",

--- a/packages/i18n/src/messages/ko/settings.json
+++ b/packages/i18n/src/messages/ko/settings.json
@@ -519,6 +519,8 @@
       "maxFileSizeDescription": "다운로드한 비디오 파일의 최대 크기",
       "ytDlpVersion": "yt-dlp 버전",
       "ytDlpVersionDescription": "비디오 다운로드에 사용할 yt-dlp 버전",
+      "ytDlpProxy": "yt-dlp Proxy",
+      "ytDlpProxyDescription": "yt-dlp용 HTTP/SOCKS5 프록시",
       "transcription": "전사",
       "transcriptionDescription": "레시피 추출을 위해 동영상 오디오를 텍스트로 변환",
       "transcriptionProvider": "음성 변환 제공업체",

--- a/packages/i18n/src/messages/nl/settings.json
+++ b/packages/i18n/src/messages/nl/settings.json
@@ -519,6 +519,8 @@
       "maxFileSizeDescription": "Maximale grootte voor gedownloade videobestanden",
       "ytDlpVersion": "yt-dlp Versie",
       "ytDlpVersionDescription": "Versie van yt-dlp voor video-downloads",
+      "ytDlpProxy": "yt-dlp Proxy",
+      "ytDlpProxyDescription": "HTTP/SOCKS5-proxy voor yt-dlp",
       "transcription": "Transcriptie",
       "transcriptionDescription": "Converteer video-audio naar tekst voor receptextractie",
       "transcriptionProvider": "Transcriptieprovider",

--- a/packages/i18n/src/messages/pl/settings.json
+++ b/packages/i18n/src/messages/pl/settings.json
@@ -519,6 +519,8 @@
       "maxFileSizeDescription": "Maksymalny rozmiar pobieranego pliku wideo",
       "ytDlpVersion": "Wersja yt-dlp",
       "ytDlpVersionDescription": "Wersja yt-dlp używana do pobierania wideo",
+      "ytDlpProxy": "yt-dlp Proxy",
+      "ytDlpProxyDescription": "Proxy HTTP/SOCKS5 dla yt-dlp",
       "transcription": "Transkrypcja",
       "transcriptionDescription": "Zamień dźwięk z wideo na tekst do ekstrakcji przepisu",
       "transcriptionProvider": "Dostawca transkrypcji",

--- a/packages/i18n/src/messages/ru/settings.json
+++ b/packages/i18n/src/messages/ru/settings.json
@@ -519,6 +519,8 @@
       "maxFileSizeDescription": "Максимальный размер загружаемых видеофайлов",
       "ytDlpVersion": "Версия yt-dlp",
       "ytDlpVersionDescription": "Версия yt-dlp для загрузки видео",
+      "ytDlpProxy": "yt-dlp Proxy",
+      "ytDlpProxyDescription": "HTTP/SOCKS5-прокси для yt-dlp",
       "transcription": "Транскрибация",
       "transcriptionDescription": "Преобразование аудио в текст для извлечения рецептов",
       "transcriptionProvider": "Провайдер транскрибации",

--- a/packages/shared-server/src/config/defaults.ts
+++ b/packages/shared-server/src/config/defaults.ts
@@ -39,6 +39,7 @@ export function getDefaultConfigValue(key: ServerConfigKey): unknown {
         maxLengthSeconds: 120,
         maxVideoFileSize: SERVER_CONFIG.MAX_VIDEO_FILE_SIZE,
         ytDlpVersion: "2025.11.12",
+        ytDlpProxy: undefined,
         transcriptionProvider: "disabled",
         transcriptionModel: "whisper-1",
       };

--- a/packages/shared/src/contracts/zod/server-config.ts
+++ b/packages/shared/src/contracts/zod/server-config.ts
@@ -324,6 +324,7 @@ export const VideoConfigSchema = z.object({
   maxLengthSeconds: z.number().int().positive(),
   maxVideoFileSize: z.number().int().positive(), // Max video file size in bytes
   ytDlpVersion: z.string().min(1),
+  ytDlpProxy: z.string().optional(),
   // Transcription settings (required for video processing)
   transcriptionProvider: TranscriptionProviderSchema,
   transcriptionEndpoint: z.url("Endpoint must be a valid URL").optional(),


### PR DESCRIPTION
## Description
This adds proxy support for yt-dlp command using the `--proxy` flag. Helpful for social media website recipe parsing.

<!-- Provide a brief summary of the changes in this PR -->

## Related Issue(s)

<!-- Link to the related issue(s) this PR addresses -->

Fixes #

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] Other (please describe):

## Screenshots (if applicable)

## Checklist

<!-- Mark the appropriate options with an "x" -->

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

<!-- Add any other context about the PR here -->
