### PR TITLE
feat: Viewable job queue - admin UI for inspecting background jobs

### DIFF
--- a/apps/web/app/(app)/settings/admin/components/admin-settings-content.tsx
+++ b/apps/web/app/(app)/settings/admin/components/admin-settings-content.tsx
@@ -7,6 +7,7 @@ import AIProcessingCard from "./ai-processing-card";
 import { AuthProvidersCard } from "./auth-providers";
 import ContentDetectionCard from "./content-detection-card";
 import GeneralCard from "./general-card";
+import JobsCard from "./jobs-card";
 import PermissionPolicyCard from "./permission-policy-card";
 import AdminShareLinksCard from "./share-links-card";
 import SystemCard from "./system-card";
@@ -26,6 +27,7 @@ function AdminSettingsContent() {
       <AuthProvidersCard />
       <ContentDetectionCard />
       <AIProcessingCard />
+      <JobsCard />
       <SystemCard />
     </div>
   );

--- a/apps/web/app/(app)/settings/admin/components/job-detail-modal.tsx
+++ b/apps/web/app/(app)/settings/admin/components/job-detail-modal.tsx
@@ -1,0 +1,284 @@
+"use client";
+
+import { useJobDetailQuery } from "@/hooks/admin/use-jobs-query";
+import {
+  CheckCircleIcon,
+  ClockIcon,
+  ExclamationTriangleIcon,
+  ForwardIcon,
+  XCircleIcon,
+} from "@heroicons/react/16/solid";
+import {
+  Chip,
+  Code,
+  Divider,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalHeader,
+  Spinner,
+} from "@heroui/react";
+import { useTranslations } from "next-intl";
+
+import { JobStatusBadge } from "./job-status-badge";
+
+interface JobDetailModalProps {
+  jobId: string | null;
+  onClose: () => void;
+}
+
+export default function JobDetailModal({ jobId, onClose }: JobDetailModalProps) {
+  const t = useTranslations("settings.admin.jobs");
+  const { job, isLoading } = useJobDetailQuery(jobId);
+
+  return (
+    <Modal
+      isOpen={!!jobId}
+      scrollBehavior="inside"
+      size="2xl"
+      onClose={onClose}
+    >
+      <ModalContent>
+        <ModalHeader className="flex items-center gap-2">
+          {t("detail.title")}
+          {job && <JobStatusBadge status={job.status} />}
+        </ModalHeader>
+        <ModalBody className="gap-4 pb-6">
+          {isLoading || !job ? (
+            <div className="flex justify-center py-8">
+              <Spinner />
+            </div>
+          ) : (
+            <>
+              {/* Metadata grid */}
+              <div className="grid grid-cols-2 gap-3 text-sm">
+                <MetaField label={t("detail.queue")} value={t(`queues.${job.queueName}` as any)} />
+                <MetaField label={t("detail.jobId")} value={job.jobId} mono />
+                {job.description && (
+                  <MetaField
+                    label={t("detail.description")}
+                    value={job.description}
+                    span2
+                  />
+                )}
+                {job.aiModel && (
+                  <MetaField label={t("detail.aiModel")} value={job.aiModel} />
+                )}
+                {job.recipeId && (
+                  <MetaField label={t("detail.recipe")} value={job.recipeId} mono />
+                )}
+                <MetaField
+                  label={t("detail.createdAt")}
+                  value={formatDateTime(job.createdAt)}
+                />
+                {job.startedAt && (
+                  <MetaField
+                    label={t("detail.startedAt")}
+                    value={formatDateTime(job.startedAt)}
+                  />
+                )}
+                {job.completedAt && (
+                  <MetaField
+                    label={t("detail.completedAt")}
+                    value={formatDateTime(job.completedAt)}
+                  />
+                )}
+                {job.startedAt && job.completedAt && (
+                  <MetaField
+                    label={t("detail.duration")}
+                    value={formatDuration(job.startedAt, job.completedAt)}
+                  />
+                )}
+              </div>
+
+              {/* Error section */}
+              {job.error && (
+                <>
+                  <Divider />
+                  <div>
+                    <h4 className="text-danger mb-1 text-sm font-semibold">
+                      {t("detail.error")}
+                    </h4>
+                    <Code className="text-danger block max-h-32 overflow-auto whitespace-pre-wrap text-xs">
+                      {job.error}
+                    </Code>
+                  </div>
+                </>
+              )}
+
+              {/* Pipeline steps */}
+              <Divider />
+              <div>
+                <h4 className="mb-3 text-sm font-semibold">{t("detail.steps")}</h4>
+                <div className="flex flex-col gap-1">
+                  {(job.steps as StepRecord[] | null)?.map((step, idx) => (
+                    <StepRow key={idx} step={step} />
+                  ))}
+                </div>
+              </div>
+
+              {/* Input data */}
+              {job.input && (
+                <>
+                  <Divider />
+                  <div>
+                    <h4 className="mb-1 text-sm font-semibold">{t("detail.input")}</h4>
+                    <Code className="block max-h-40 overflow-auto whitespace-pre-wrap text-xs">
+                      {JSON.stringify(job.input, null, 2)}
+                    </Code>
+                  </div>
+                </>
+              )}
+
+              {/* Result data */}
+              {job.result && (
+                <>
+                  <Divider />
+                  <div>
+                    <h4 className="mb-1 text-sm font-semibold">{t("detail.result")}</h4>
+                    <Code className="block max-h-40 overflow-auto whitespace-pre-wrap text-xs">
+                      {JSON.stringify(job.result, null, 2)}
+                    </Code>
+                  </div>
+                </>
+              )}
+            </>
+          )}
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+}
+
+interface StepRecord {
+  name: string;
+  status: string;
+  startedAt?: string;
+  completedAt?: string;
+  output?: unknown;
+  error?: string;
+}
+
+function StepRow({ step }: { step: StepRecord }) {
+  const t = useTranslations("settings.admin.jobs.stepStatus");
+
+  return (
+    <div className="flex items-start gap-2 rounded-md px-2 py-1.5">
+      {/* Status icon */}
+      <StepIcon status={step.status} />
+
+      {/* Step name + timing */}
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium capitalize">
+            {step.name.replace(/_/g, " ")}
+          </span>
+          <Chip
+            className="h-5"
+            color={stepChipColor(step.status)}
+            size="sm"
+            variant="dot"
+          >
+            {t(step.status as any)}
+          </Chip>
+        </div>
+
+        {/* Timing */}
+        {step.startedAt && step.completedAt && (
+          <span className="text-default-400 text-xs">
+            {formatDuration(step.startedAt, step.completedAt)}
+          </span>
+        )}
+
+        {/* Error */}
+        {step.error && (
+          <p className="text-danger mt-0.5 text-xs">{step.error}</p>
+        )}
+
+        {/* Output preview */}
+        {step.output && !step.error && (
+          <p className="text-default-400 mt-0.5 truncate text-xs">
+            {typeof step.output === "string"
+              ? step.output
+              : JSON.stringify(step.output)}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function StepIcon({ status }: { status: string }) {
+  const className = "h-4 w-4 mt-0.5 shrink-0";
+
+  switch (status) {
+    case "completed":
+      return <CheckCircleIcon className={`${className} text-success`} />;
+    case "failed":
+      return <XCircleIcon className={`${className} text-danger`} />;
+    case "active":
+      return <Spinner className={className} size="sm" />;
+    case "skipped":
+      return <ForwardIcon className={`${className} text-default-300`} />;
+    default:
+      return <ClockIcon className={`${className} text-default-300`} />;
+  }
+}
+
+function stepChipColor(status: string): "default" | "primary" | "success" | "danger" | "warning" {
+  switch (status) {
+    case "completed":
+      return "success";
+    case "failed":
+      return "danger";
+    case "active":
+      return "primary";
+    case "skipped":
+      return "warning";
+    default:
+      return "default";
+  }
+}
+
+function MetaField({
+  label,
+  value,
+  mono,
+  span2,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+  span2?: boolean;
+}) {
+  return (
+    <div className={span2 ? "col-span-2" : ""}>
+      <span className="text-default-400 text-xs">{label}</span>
+      <p className={`text-sm ${mono ? "font-mono" : ""} truncate`}>{value}</p>
+    </div>
+  );
+}
+
+function formatDateTime(date: string | Date | null): string {
+  if (!date) return "—";
+
+  return new Date(date).toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
+function formatDuration(start: string | Date, end: string | Date): string {
+  const ms = new Date(end).getTime() - new Date(start).getTime();
+
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+
+  const min = Math.floor(ms / 60_000);
+  const sec = Math.round((ms % 60_000) / 1000);
+
+  return `${min}m ${sec}s`;
+}

--- a/apps/web/app/(app)/settings/admin/components/job-status-badge.tsx
+++ b/apps/web/app/(app)/settings/admin/components/job-status-badge.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { Chip } from "@heroui/react";
+import { useTranslations } from "next-intl";
+
+type JobStatus = "queued" | "active" | "completed" | "failed";
+
+const statusColorMap: Record<JobStatus, "default" | "primary" | "success" | "danger"> = {
+  queued: "default",
+  active: "primary",
+  completed: "success",
+  failed: "danger",
+};
+
+export function JobStatusBadge({ status }: { status: string }) {
+  const t = useTranslations("settings.admin.jobs.status");
+  const color = statusColorMap[status as JobStatus] ?? "default";
+
+  return (
+    <Chip color={color} size="sm" variant="flat">
+      {t(status as any)}
+    </Chip>
+  );
+}

--- a/apps/web/app/(app)/settings/admin/components/jobs-card.tsx
+++ b/apps/web/app/(app)/settings/admin/components/jobs-card.tsx
@@ -1,0 +1,287 @@
+"use client";
+
+import { useState } from "react";
+import { useJobsListQuery, useJobStatsQuery } from "@/hooks/admin/use-jobs-query";
+import {
+  ArrowPathIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  QueueListIcon,
+} from "@heroicons/react/16/solid";
+import {
+  Button,
+  Card,
+  CardBody,
+  CardHeader,
+  Chip,
+  Divider,
+  Select,
+  SelectItem,
+  Spinner,
+} from "@heroui/react";
+import { useTranslations } from "next-intl";
+
+import JobDetailModal from "./job-detail-modal";
+import { JobStatusBadge } from "./job-status-badge";
+
+const QUEUE_OPTIONS = [
+  "recipe-import",
+  "image-recipe-import",
+  "paste-recipe-import",
+  "caldav-sync",
+  "scheduled-tasks",
+  "nutrition-estimation",
+  "auto-tagging",
+  "auto-categorization",
+  "allergy-detection",
+] as const;
+
+const STATUS_OPTIONS = ["queued", "active", "completed", "failed"] as const;
+
+const PAGE_SIZE = 10;
+
+export default function JobsCard() {
+  const t = useTranslations("settings.admin.jobs");
+
+  const [queueFilter, setQueueFilter] = useState<string>("");
+  const [statusFilter, setStatusFilter] = useState<string>("");
+  const [page, setPage] = useState(0);
+  const [selectedJobId, setSelectedJobId] = useState<string | null>(null);
+
+  const { jobs, total, isLoading, invalidate } = useJobsListQuery({
+    limit: PAGE_SIZE,
+    offset: page * PAGE_SIZE,
+    queueName: queueFilter || undefined,
+    status: (statusFilter as "queued" | "active" | "completed" | "failed") || undefined,
+  });
+
+  const { stats } = useJobStatsQuery();
+
+  const totalPages = Math.ceil(total / PAGE_SIZE);
+  const from = page * PAGE_SIZE + 1;
+  const to = Math.min((page + 1) * PAGE_SIZE, total);
+
+  return (
+    <>
+      <Card>
+        <CardHeader className="flex items-center justify-between">
+          <h2 className="flex items-center gap-2 text-lg font-semibold">
+            <QueueListIcon className="h-5 w-5" />
+            {t("title")}
+          </h2>
+          <div className="flex items-center gap-2">
+            {/* Stats chips */}
+            {(stats.byStatus.active ?? 0) > 0 && (
+              <Chip color="primary" size="sm" variant="flat">
+                {stats.byStatus.active} {t("stats.active")}
+              </Chip>
+            )}
+            {(stats.byStatus.failed ?? 0) > 0 && (
+              <Chip color="danger" size="sm" variant="flat">
+                {stats.byStatus.failed} {t("stats.failed")}
+              </Chip>
+            )}
+            <Button
+              isIconOnly
+              size="sm"
+              variant="light"
+              onPress={invalidate}
+            >
+              <ArrowPathIcon className="h-4 w-4" />
+            </Button>
+          </div>
+        </CardHeader>
+        <CardBody className="gap-4">
+          {/* Filters */}
+          <div className="flex flex-wrap gap-3">
+            <Select
+              className="max-w-[200px]"
+              label={t("filters.allQueues")}
+              selectedKeys={queueFilter ? [queueFilter] : []}
+              size="sm"
+              onSelectionChange={(keys) => {
+                const val = Array.from(keys)[0] as string;
+
+                setQueueFilter(val ?? "");
+                setPage(0);
+              }}
+            >
+              {QUEUE_OPTIONS.map((q) => (
+                <SelectItem key={q}>{t(`queues.${q}`)}</SelectItem>
+              ))}
+            </Select>
+
+            <Select
+              className="max-w-[180px]"
+              label={t("filters.allStatuses")}
+              selectedKeys={statusFilter ? [statusFilter] : []}
+              size="sm"
+              onSelectionChange={(keys) => {
+                const val = Array.from(keys)[0] as string;
+
+                setStatusFilter(val ?? "");
+                setPage(0);
+              }}
+            >
+              {STATUS_OPTIONS.map((s) => (
+                <SelectItem key={s}>{t(`status.${s}`)}</SelectItem>
+              ))}
+            </Select>
+          </div>
+
+          <Divider />
+
+          {/* Job list */}
+          {isLoading ? (
+            <div className="flex justify-center py-8">
+              <Spinner />
+            </div>
+          ) : jobs.length === 0 ? (
+            <p className="text-default-400 py-8 text-center text-sm">{t("empty")}</p>
+          ) : (
+            <div className="flex flex-col gap-2">
+              {jobs.map((job) => (
+                <button
+                  key={job.id}
+                  className="hover:bg-default-100 flex items-center gap-3 rounded-lg p-3 text-left transition-colors"
+                  type="button"
+                  onClick={() => setSelectedJobId(job.id)}
+                >
+                  {/* Progress indicator */}
+                  <JobProgressCircle steps={job.steps as any} status={job.status} />
+
+                  {/* Job info */}
+                  <div className="min-w-0 flex-1">
+                    <div className="text-default-400 text-xs">
+                      {t(`queues.${job.queueName}` as any)}
+                    </div>
+                    <div className="truncate text-sm font-medium">
+                      {job.description || job.jobId}
+                    </div>
+                  </div>
+
+                  {/* Status badge */}
+                  <JobStatusBadge status={job.status} />
+
+                  {/* Timestamp */}
+                  <span className="text-default-400 hidden text-xs whitespace-nowrap sm:block">
+                    {formatRelativeTime(job.createdAt)}
+                  </span>
+                </button>
+              ))}
+            </div>
+          )}
+
+          {/* Pagination */}
+          {total > PAGE_SIZE && (
+            <>
+              <Divider />
+              <div className="flex items-center justify-between">
+                <span className="text-default-500 text-xs">
+                  {t("pagination.showing", { from, to, total })}
+                </span>
+                <div className="flex gap-1">
+                  <Button
+                    isIconOnly
+                    isDisabled={page === 0}
+                    size="sm"
+                    variant="flat"
+                    onPress={() => setPage((p) => p - 1)}
+                  >
+                    <ChevronLeftIcon className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    isIconOnly
+                    isDisabled={page >= totalPages - 1}
+                    size="sm"
+                    variant="flat"
+                    onPress={() => setPage((p) => p + 1)}
+                  >
+                    <ChevronRightIcon className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+            </>
+          )}
+        </CardBody>
+      </Card>
+
+      {/* Detail modal */}
+      <JobDetailModal
+        jobId={selectedJobId}
+        onClose={() => setSelectedJobId(null)}
+      />
+    </>
+  );
+}
+
+/**
+ * Small SVG progress circle showing pipeline completion.
+ */
+function JobProgressCircle({
+  steps,
+  status,
+}: {
+  steps: { status: string }[] | null;
+  status: string;
+}) {
+  const totalSteps = steps?.length || 1;
+  const completedSteps = steps?.filter(
+    (s) => s.status === "completed" || s.status === "skipped"
+  ).length ?? 0;
+
+  const circumference = 2 * Math.PI * 14;
+  const progress = totalSteps > 0 ? completedSteps / totalSteps : 0;
+  const dashArray = `${progress * circumference}, ${circumference}`;
+
+  let strokeColor = "stroke-primary"; // active/queued
+
+  if (status === "completed") strokeColor = "stroke-success";
+  if (status === "failed") strokeColor = "stroke-danger";
+
+  return (
+    <svg className="h-8 w-8 -rotate-90" viewBox="0 0 32 32">
+      <circle
+        className="stroke-default-200"
+        cx="16"
+        cy="16"
+        fill="none"
+        r="14"
+        strokeDasharray="2, 1"
+        strokeWidth="3"
+      />
+      <circle
+        className={strokeColor}
+        cx="16"
+        cy="16"
+        fill="none"
+        r="14"
+        strokeDasharray={dashArray}
+        strokeLinecap="round"
+        strokeWidth="3"
+      />
+    </svg>
+  );
+}
+
+/**
+ * Format a date as relative time (e.g. "2m ago", "1h ago").
+ */
+function formatRelativeTime(date: string | Date | null): string {
+  if (!date) return "";
+  const now = Date.now();
+  const then = new Date(date).getTime();
+  const diffMs = now - then;
+  const diffSec = Math.floor(diffMs / 1000);
+
+  if (diffSec < 60) return `${diffSec}s ago`;
+  const diffMin = Math.floor(diffSec / 60);
+
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.floor(diffMin / 60);
+
+  if (diffHr < 24) return `${diffHr}h ago`;
+  const diffDay = Math.floor(diffHr / 24);
+
+  return `${diffDay}d ago`;
+}

--- a/apps/web/components/navbar/mobile-nav.tsx
+++ b/apps/web/components/navbar/mobile-nav.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef } from "react";
 import NextLink from "next/link";
 import { usePathname } from "next/navigation";
+import NavbarJobsDropdown from "@/components/navbar/navbar-jobs-dropdown";
 import NavbarUserMenu from "@/components/navbar/navbar-user-menu";
 import { useUserContext } from "@/context/user-context";
 import { useAutoHide } from "@/hooks/auto-hide";
@@ -116,6 +117,13 @@ export const MobileNav = () => {
                 );
               })}
             </ul>
+          </div>
+
+          {/* Jobs dropdown (admin only) */}
+          <div
+            className={`flex h-13 w-13 shrink-0 items-center justify-center rounded-full ${cssGlassBackdrop}`}
+          >
+            <NavbarJobsDropdown />
           </div>
 
           {/* User menu */}

--- a/apps/web/components/navbar/navbar-jobs-dropdown.tsx
+++ b/apps/web/components/navbar/navbar-jobs-dropdown.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useJobsListQuery, useJobStatsQuery } from "@/hooks/admin/use-jobs-query";
+import { useUserRoleQuery } from "@/hooks/admin";
+import { QueueListIcon } from "@heroicons/react/16/solid";
+import {
+  Badge,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  Button,
+  Spinner,
+  Divider,
+  Chip,
+} from "@heroui/react";
+import { useTranslations } from "next-intl";
+
+import JobDetailModal from "@/app/(app)/settings/admin/components/job-detail-modal";
+
+export default function NavbarJobsDropdown() {
+  const { isServerAdmin, isLoading: roleLoading } = useUserRoleQuery();
+  const tJobs = useTranslations("navbar.jobs");
+  const tStatus = useTranslations("settings.admin.jobs.status");
+  const tQueues = useTranslations("settings.admin.jobs.queues");
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedJobId, setSelectedJobId] = useState<string | null>(null);
+  const router = useRouter();
+
+  const { jobs, isLoading } = useJobsListQuery({
+    limit: 6,
+    offset: 0,
+  });
+
+  const { stats } = useJobStatsQuery();
+  const activeCount = (stats.byStatus.active ?? 0) + (stats.byStatus.queued ?? 0);
+
+  // Don't render for non-admins
+  if (roleLoading || !isServerAdmin) return null;
+
+  return (
+    <>
+      <Popover
+        isOpen={isOpen}
+        placement="bottom-end"
+        onOpenChange={setIsOpen}
+      >
+        <PopoverTrigger>
+          <button
+            aria-label={tJobs("title")}
+            className="relative rounded-full p-2 transition-colors hover:bg-default-100"
+            type="button"
+          >
+            <Badge
+              color="primary"
+              content={activeCount}
+              isInvisible={activeCount === 0}
+              shape="circle"
+              size="sm"
+            >
+              <QueueListIcon className="text-foreground/70 h-5 w-5" />
+            </Badge>
+          </button>
+        </PopoverTrigger>
+
+        <PopoverContent className="w-[340px] p-0">
+          {/* Header */}
+          <div className="flex items-center justify-between px-4 pt-3 pb-2">
+            <span className="text-xs font-bold uppercase tracking-wide text-default-400">
+              {tJobs("title")}
+            </span>
+            {activeCount > 0 && (
+              <Chip color="primary" size="sm" variant="flat">
+                {tJobs("active", { count: activeCount })}
+              </Chip>
+            )}
+          </div>
+
+          <Divider />
+
+          {/* Job list */}
+          <div className="max-h-[320px] overflow-y-auto">
+            {isLoading ? (
+              <div className="flex justify-center py-6">
+                <Spinner size="sm" />
+              </div>
+            ) : jobs.length === 0 ? (
+              <p className="py-6 text-center text-sm text-default-400">
+                {tJobs("empty")}
+              </p>
+            ) : (
+              jobs.map((job) => (
+                <button
+                  key={job.id}
+                  className="flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors hover:bg-default-50"
+                  type="button"
+                  onClick={() => {
+                    setIsOpen(false);
+                    setSelectedJobId(job.id);
+                  }}
+                >
+                  {/* Progress circle */}
+                  <JobMiniCircle steps={job.steps as StepInfo[] | null} status={job.status} />
+
+                  {/* Info */}
+                  <div className="min-w-0 flex-1">
+                    <span className="block truncate text-[13px] font-semibold text-foreground">
+                      {job.description || job.jobId}
+                    </span>
+                    <span className="text-[11px] text-default-400">
+                      {tQueues(job.queueName as any)}
+                    </span>
+                  </div>
+
+                  {/* Status badge */}
+                  <JobMiniBadge status={job.status} label={tStatus(job.status as any)} />
+                </button>
+              ))
+            )}
+          </div>
+
+          {/* Footer */}
+          <Divider />
+          <div className="px-4 py-2">
+            <Button
+              className="w-full"
+              size="sm"
+              variant="flat"
+              onPress={() => {
+                setIsOpen(false);
+                router.push("/settings?tab=admin");
+              }}
+            >
+              {tJobs("viewAll")}
+            </Button>
+          </div>
+        </PopoverContent>
+      </Popover>
+
+      {/* Detail modal */}
+      <JobDetailModal
+        jobId={selectedJobId}
+        onClose={() => setSelectedJobId(null)}
+      />
+    </>
+  );
+}
+
+// ── Tiny helpers ────────────────────────────────────────────────────────────
+
+interface StepInfo {
+  status: string;
+}
+
+function JobMiniCircle({ steps, status }: { steps: StepInfo[] | null; status: string }) {
+  const total = steps?.length || 1;
+  const done = steps?.filter((s) => s.status === "completed" || s.status === "skipped").length ?? 0;
+  const circumference = 2 * Math.PI * 10;
+  const dash = `${(done / total) * circumference}, ${circumference}`;
+
+  let color = "stroke-primary";
+
+  if (status === "completed") color = "stroke-success";
+  if (status === "failed") color = "stroke-danger";
+
+  return (
+    <svg className="h-6 w-6 shrink-0 -rotate-90" viewBox="0 0 24 24">
+      <circle
+        className="stroke-default-200"
+        cx="12"
+        cy="12"
+        fill="none"
+        r="10"
+        strokeDasharray="2,1"
+        strokeWidth="2.5"
+      />
+      <circle
+        className={color}
+        cx="12"
+        cy="12"
+        fill="none"
+        r="10"
+        strokeDasharray={dash}
+        strokeLinecap="round"
+        strokeWidth="2.5"
+      />
+    </svg>
+  );
+}
+
+function JobMiniBadge({ status, label }: { status: string; label: string }) {
+  const colorMap: Record<string, "default" | "primary" | "success" | "danger"> = {
+    queued: "default",
+    active: "primary",
+    completed: "success",
+    failed: "danger",
+  };
+
+  return (
+    <Chip
+      className="h-5 min-w-0 shrink-0 text-[10px] font-bold"
+      color={colorMap[status] ?? "default"}
+      size="sm"
+      variant="flat"
+    >
+      {label}
+    </Chip>
+  );
+}

--- a/apps/web/components/navbar/navbar-jobs-dropdown.tsx
+++ b/apps/web/components/navbar/navbar-jobs-dropdown.tsx
@@ -81,7 +81,7 @@ export default function NavbarJobsDropdown() {
           <Divider />
 
           {/* Job list */}
-          <div className="max-h-[320px] overflow-y-auto">
+          <div className="max-h-[320px] w-full overflow-y-auto overflow-x-hidden">
             {isLoading ? (
               <div className="flex justify-center py-6">
                 <Spinner size="sm" />
@@ -94,7 +94,7 @@ export default function NavbarJobsDropdown() {
               jobs.map((job) => (
                 <button
                   key={job.id}
-                  className="flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors hover:bg-default-50"
+                  className="flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors hover:bg-default-50 min-w-0"
                   type="button"
                   onClick={() => {
                     setIsOpen(false);

--- a/apps/web/components/navbar/navbar.tsx
+++ b/apps/web/components/navbar/navbar.tsx
@@ -4,6 +4,7 @@ import NextLink from "next/link";
 import { usePathname } from "next/navigation";
 import { BrandLogo } from "@/components/brand/brand-logo";
 import MobileNav from "@/components/navbar/mobile-nav";
+import NavbarJobsDropdown from "@/components/navbar/navbar-jobs-dropdown";
 import NavbarUserMenu from "@/components/navbar/navbar-user-menu";
 import { useAutoHide } from "@/hooks/auto-hide";
 import { Navbar as HeroUINavbar, NavbarBrand, NavbarContent, NavbarItem } from "@heroui/navbar";
@@ -94,6 +95,9 @@ export const Navbar = () => {
 
           {/* Right */}
           <NavbarContent className="items-center" justify="end">
+            <NavbarItem className="flex items-center">
+              <NavbarJobsDropdown />
+            </NavbarItem>
             <NavbarItem className="flex items-center">
               <NavbarUserMenu />
             </NavbarItem>

--- a/apps/web/hooks/admin/use-jobs-query.ts
+++ b/apps/web/hooks/admin/use-jobs-query.ts
@@ -1,0 +1,86 @@
+"use client";
+
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useTRPC } from "@/app/providers/trpc-provider";
+
+export interface JobsListParams {
+  limit?: number;
+  offset?: number;
+  queueName?: string;
+  status?: "queued" | "active" | "completed" | "failed";
+  userId?: string;
+  fromDate?: string;
+  toDate?: string;
+}
+
+export function useJobsListQuery(params: JobsListParams = {}) {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+
+  const queryOptions = trpc.admin.jobs.listJobs.queryOptions({
+    limit: params.limit ?? 20,
+    offset: params.offset ?? 0,
+    queueName: params.queueName,
+    status: params.status,
+    userId: params.userId,
+    fromDate: params.fromDate,
+    toDate: params.toDate,
+  });
+
+  const { data, error, isLoading } = useQuery({
+    ...queryOptions,
+    refetchInterval: 10_000, // Poll every 10s for active jobs
+  });
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: queryOptions.queryKey });
+  };
+
+  return {
+    jobs: data?.jobs ?? [],
+    total: data?.total ?? 0,
+    error,
+    isLoading,
+    invalidate,
+  };
+}
+
+export function useJobDetailQuery(id: string | null) {
+  const trpc = useTRPC();
+
+  const { data, error, isLoading } = useQuery({
+    ...trpc.admin.jobs.getJob.queryOptions({ id: id! }),
+    enabled: !!id,
+    refetchInterval: (query) => {
+      // Poll only if job is active
+      const job = query.state.data;
+
+      if (job && (job.status === "active" || job.status === "queued")) {
+        return 3_000;
+      }
+
+      return false;
+    },
+  });
+
+  return {
+    job: data ?? null,
+    error,
+    isLoading,
+  };
+}
+
+export function useJobStatsQuery() {
+  const trpc = useTRPC();
+
+  const { data, error, isLoading } = useQuery({
+    ...trpc.admin.jobs.stats.queryOptions(),
+    refetchInterval: 15_000,
+  });
+
+  return {
+    stats: data ?? { byStatus: {}, byQueue: {} },
+    error,
+    isLoading,
+  };
+}

--- a/packages/db/src/migrations/0035_add_job_logs.sql
+++ b/packages/db/src/migrations/0035_add_job_logs.sql
@@ -1,0 +1,49 @@
+-- Job status enum
+DO $$ BEGIN
+  CREATE TYPE "public"."job_status" AS ENUM('queued', 'active', 'completed', 'failed');
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+-- Job step status enum
+DO $$ BEGIN
+  CREATE TYPE "public"."job_step_status" AS ENUM('pending', 'active', 'completed', 'failed', 'skipped');
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS "job_logs" (
+  "id" text PRIMARY KEY NOT NULL,
+  "job_id" text NOT NULL,
+  "queue_name" text NOT NULL,
+  "status" "job_status" DEFAULT 'queued' NOT NULL,
+  "user_id" text,
+  "recipe_id" text,
+  "description" text,
+  "input" jsonb,
+  "steps" jsonb DEFAULT '[]'::jsonb,
+  "result" jsonb,
+  "error" text,
+  "ai_model" text,
+  "started_at" timestamp with time zone,
+  "completed_at" timestamp with time zone,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+--> statement-breakpoint
+
+DO $$ BEGIN
+  ALTER TABLE "job_logs" ADD CONSTRAINT "job_logs_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "job_logs_queue_name_idx" ON "job_logs" USING btree ("queue_name");
+CREATE INDEX IF NOT EXISTS "job_logs_status_idx" ON "job_logs" USING btree ("status");
+CREATE INDEX IF NOT EXISTS "job_logs_user_id_idx" ON "job_logs" USING btree ("user_id");
+CREATE INDEX IF NOT EXISTS "job_logs_recipe_id_idx" ON "job_logs" USING btree ("recipe_id");
+CREATE INDEX IF NOT EXISTS "job_logs_created_at_idx" ON "job_logs" USING btree ("created_at");

--- a/packages/db/src/migrations/meta/0035_snapshot.json
+++ b/packages/db/src/migrations/meta/0035_snapshot.json
@@ -1,0 +1,4180 @@
+{
+  "id": "0bb4a4c4-12c1-44ac-ae68-5c48a31d478e",
+  "prevId": "627d2038-3451-4a3c-a167-0d800805e7a9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_logs": {
+      "name": "api_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "procedure": {
+          "name": "procedure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'true'"
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_logs_procedure_idx": {
+          "name": "api_logs_procedure_idx",
+          "columns": [
+            {
+              "expression": "procedure",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_logs_user_id_idx": {
+          "name": "api_logs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_logs_created_at_idx": {
+          "name": "api_logs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_logs_success_idx": {
+          "name": "api_logs_success_idx",
+          "columns": [
+            {
+              "expression": "success",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_logs_user_id_user_id_fk": {
+          "name": "api_logs_user_id_user_id_fk",
+          "tableFrom": "api_logs",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_provider_unique": {
+          "name": "account_provider_unique",
+          "columns": [
+            {
+              "expression": "providerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "accountId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apikey": {
+      "name": "apikey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configId": {
+          "name": "configId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refillInterval": {
+          "name": "refillInterval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refillAmount": {
+          "name": "refillAmount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastRefillAt": {
+          "name": "lastRefillAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "rateLimitEnabled": {
+          "name": "rateLimitEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "rateLimitTimeWindow": {
+          "name": "rateLimitTimeWindow",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 60000
+        },
+        "rateLimitMax": {
+          "name": "rateLimitMax",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 100
+        },
+        "requestCount": {
+          "name": "requestCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "lastRequest": {
+          "name": "lastRequest",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "apikey_key_idx": {
+          "name": "apikey_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "apikey_user_id_idx": {
+          "name": "apikey_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "apikey_userId_user_id_fk": {
+          "name": "apikey_userId_user_id_fk",
+          "tableFrom": "apikey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailHmac": {
+          "name": "emailHmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isServerOwner": {
+          "name": "isServerOwner",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isServerAdmin": {
+          "name": "isServerAdmin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "user_email_hmac_idx": {
+          "name": "user_email_hmac_idx",
+          "columns": [
+            {
+              "expression": "emailHmac",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_single_server_owner_idx": {
+          "name": "user_single_server_owner_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user\".\"isServerOwner\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_caldav_config": {
+      "name": "user_caldav_config",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "server_url_enc": {
+          "name": "server_url_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendar_url_enc": {
+          "name": "calendar_url_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username_enc": {
+          "name": "username_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_enc": {
+          "name": "password_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "breakfast_time": {
+          "name": "breakfast_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'08:00-09:00'"
+        },
+        "lunch_time": {
+          "name": "lunch_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'12:00-13:00'"
+        },
+        "dinner_time": {
+          "name": "dinner_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'18:00-19:00'"
+        },
+        "snack_time": {
+          "name": "snack_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'15:00-15:30'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_caldav_config_user_id_user_id_fk": {
+          "name": "user_caldav_config_user_id_user_id_fk",
+          "tableFrom": "user_caldav_config",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caldav_sync_status": {
+      "name": "caldav_sync_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "caldav_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "planned_item_id": {
+          "name": "planned_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_title": {
+          "name": "event_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "caldav_sync_status_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "caldav_event_uid": {
+          "name": "caldav_event_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "idx_caldav_sync_user_status": {
+          "name": "idx_caldav_sync_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sync_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_caldav_sync_status_retry": {
+          "name": "idx_caldav_sync_status_retry",
+          "columns": [
+            {
+              "expression": "sync_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "retry_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_sync_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "caldav_sync_status_user_id_user_id_fk": {
+          "name": "caldav_sync_status_user_id_user_id_fk",
+          "tableFrom": "caldav_sync_status",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_caldav_sync_user_item": {
+          "name": "uq_caldav_sync_user_item",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groceries": {
+      "name": "groceries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipe_ingredient_id": {
+          "name": "recipe_ingredient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_grocery_id": {
+          "name": "recurring_grocery_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "store_id": {
+          "name": "store_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_done": {
+          "name": "is_done",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "idx_groceries_user_id": {
+          "name": "idx_groceries_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_groceries_recipe_ingredient_id": {
+          "name": "idx_groceries_recipe_ingredient_id",
+          "columns": [
+            {
+              "expression": "recipe_ingredient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_groceries_recurring_grocery_id": {
+          "name": "idx_groceries_recurring_grocery_id",
+          "columns": [
+            {
+              "expression": "recurring_grocery_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_groceries_store_id": {
+          "name": "idx_groceries_store_id",
+          "columns": [
+            {
+              "expression": "store_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_groceries_is_done": {
+          "name": "idx_groceries_is_done",
+          "columns": [
+            {
+              "expression": "is_done",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_groceries_sort_order": {
+          "name": "idx_groceries_sort_order",
+          "columns": [
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groceries_user_id_user_id_fk": {
+          "name": "groceries_user_id_user_id_fk",
+          "tableFrom": "groceries",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "groceries_recipe_ingredient_id_recipe_ingredients_id_fk": {
+          "name": "groceries_recipe_ingredient_id_recipe_ingredients_id_fk",
+          "tableFrom": "groceries",
+          "tableTo": "recipe_ingredients",
+          "columnsFrom": [
+            "recipe_ingredient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "groceries_recurring_grocery_id_recurring_groceries_id_fk": {
+          "name": "groceries_recurring_grocery_id_recurring_groceries_id_fk",
+          "tableFrom": "groceries",
+          "tableTo": "recurring_groceries",
+          "columnsFrom": [
+            "recurring_grocery_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "groceries_store_id_stores_id_fk": {
+          "name": "groceries_store_id_stores_id_fk",
+          "tableFrom": "groceries",
+          "tableTo": "stores",
+          "columnsFrom": [
+            "store_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.household_users": {
+      "name": "household_users",
+      "schema": "",
+      "columns": {
+        "household_id": {
+          "name": "household_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "idx_household_users_household_id": {
+          "name": "idx_household_users_household_id",
+          "columns": [
+            {
+              "expression": "household_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_household_users_user_id": {
+          "name": "idx_household_users_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "household_users_household_id_households_id_fk": {
+          "name": "household_users_household_id_households_id_fk",
+          "tableFrom": "household_users",
+          "tableTo": "households",
+          "columnsFrom": [
+            "household_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "household_users_user_id_user_id_fk": {
+          "name": "household_users_user_id_user_id_fk",
+          "tableFrom": "household_users",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "pk_household_users": {
+          "name": "pk_household_users",
+          "columns": [
+            "household_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.households": {
+      "name": "households",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "join_code": {
+          "name": "join_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "join_code_expires_at": {
+          "name": "join_code_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "idx_households_name": {
+          "name": "idx_households_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_households_created_at": {
+          "name": "idx_households_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_households_admin_user_id": {
+          "name": "idx_households_admin_user_id",
+          "columns": [
+            {
+              "expression": "admin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "households_admin_user_id_user_id_fk": {
+          "name": "households_admin_user_id_user_id_fk",
+          "tableFrom": "households",
+          "tableTo": "user",
+          "columnsFrom": [
+            "admin_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_households_join_code": {
+          "name": "uq_households_join_code",
+          "nullsNotDistinct": false,
+          "columns": [
+            "join_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recipes": {
+      "name": "recipes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "servings": {
+          "name": "servings",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "prep_minutes": {
+          "name": "prep_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cook_minutes": {
+          "name": "cook_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_minutes": {
+          "name": "total_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_used": {
+          "name": "system_used",
+          "type": "measurement_system",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'metric'"
+        },
+        "calories": {
+          "name": "calories",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fat": {
+          "name": "fat",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "carbs": {
+          "name": "carbs",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "protein": {
+          "name": "protein",
+          "type": "numeric(6, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "categories": {
+          "name": "categories",
+          "type": "recipe_category[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "idx_recipes_user_id": {
+          "name": "idx_recipes_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_recipes_name": {
+          "name": "idx_recipes_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_recipes_created_at_desc": {
+          "name": "idx_recipes_created_at_desc",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_recipes_total_minutes": {
+          "name": "idx_recipes_total_minutes",
+          "columns": [
+            {
+              "expression": "total_minutes",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_recipes_prep_minutes": {
+          "name": "idx_recipes_prep_minutes",
+          "columns": [
+            {
+              "expression": "prep_minutes",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_recipes_cook_minutes": {
+          "name": "idx_recipes_cook_minutes",
+          "columns": [
+            {
+              "expression": "cook_minutes",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recipes_user_id_user_id_fk": {
+          "name": "recipes_user_id_user_id_fk",
+          "tableFrom": "recipes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_recipes_url_user": {
+          "name": "uq_recipes_url_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "url",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "uqidx_tags_name_lower": {
+          "name": "uqidx_tags_name_lower",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tags_created_at": {
+          "name": "idx_tags_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingredients": {
+      "name": "ingredients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "uqidx_ingredients_name_lower": {
+          "name": "uqidx_ingredients_name_lower",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ingredients_created_at": {
+          "name": "idx_ingredients_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recipe_tags": {
+      "name": "recipe_tags",
+      "schema": "",
+      "columns": {
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "idx_recipe_tags_recipe_id": {
+          "name": "idx_recipe_tags_recipe_id",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_recipe_tags_tag_id": {
+          "name": "idx_recipe_tags_tag_id",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recipe_tags_recipe_id_recipes_id_fk": {
+          "name": "recipe_tags_recipe_id_recipes_id_fk",
+          "tableFrom": "recipe_tags",
+          "tableTo": "recipes",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recipe_tags_tag_id_tags_id_fk": {
+          "name": "recipe_tags_tag_id_tags_id_fk",
+          "tableFrom": "recipe_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "pk_recipe_tags": {
+          "name": "pk_recipe_tags",
+          "columns": [
+            "recipe_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recipe_ingredients": {
+      "name": "recipe_ingredients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ingredient_id": {
+          "name": "ingredient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_used": {
+          "name": "system_used",
+          "type": "measurement_system",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'metric'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "idx_recipe_ingredients_recipe_id": {
+          "name": "idx_recipe_ingredients_recipe_id",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_recipe_ingredients_ingredient_id": {
+          "name": "idx_recipe_ingredients_ingredient_id",
+          "columns": [
+            {
+              "expression": "ingredient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recipe_ingredients_recipe_id_recipes_id_fk": {
+          "name": "recipe_ingredients_recipe_id_recipes_id_fk",
+          "tableFrom": "recipe_ingredients",
+          "tableTo": "recipes",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recipe_ingredients_ingredient_id_ingredients_id_fk": {
+          "name": "recipe_ingredients_ingredient_id_ingredients_id_fk",
+          "tableFrom": "recipe_ingredients",
+          "tableTo": "ingredients",
+          "columnsFrom": [
+            "ingredient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.steps": {
+      "name": "steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step": {
+          "name": "step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_used": {
+          "name": "system_used",
+          "type": "measurement_system",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'metric'"
+        },
+        "order": {
+          "name": "order",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "idx_steps_recipe_id": {
+          "name": "idx_steps_recipe_id",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_recipe_step_system": {
+          "name": "unique_recipe_step_system",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "step",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "system_used",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "steps_recipe_id_recipes_id_fk": {
+          "name": "steps_recipe_id_recipes_id_fk",
+          "tableFrom": "steps",
+          "tableTo": "recipes",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.step_images": {
+      "name": "step_images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "step_id": {
+          "name": "step_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "idx_step_images_step_id": {
+          "name": "idx_step_images_step_id",
+          "columns": [
+            {
+              "expression": "step_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "step_images_step_id_steps_id_fk": {
+          "name": "step_images_step_id_steps_id_fk",
+          "tableFrom": "step_images",
+          "tableTo": "steps",
+          "columnsFrom": [
+            "step_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recipe_images": {
+      "name": "recipe_images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "idx_recipe_images_recipe_id": {
+          "name": "idx_recipe_images_recipe_id",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recipe_images_recipe_id_recipes_id_fk": {
+          "name": "recipe_images_recipe_id_recipes_id_fk",
+          "tableFrom": "recipe_images",
+          "tableTo": "recipes",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recipe_videos": {
+      "name": "recipe_videos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "video": {
+          "name": "video",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thumbnail": {
+          "name": "thumbnail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "idx_recipe_videos_recipe_id": {
+          "name": "idx_recipe_videos_recipe_id",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recipe_videos_recipe_id_recipes_id_fk": {
+          "name": "recipe_videos_recipe_id_recipes_id_fk",
+          "tableFrom": "recipe_videos",
+          "tableTo": "recipes",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.planned_items": {
+      "name": "planned_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot": {
+          "name": "slot",
+          "type": "slot_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "idx_planned_items_user_date": {
+          "name": "idx_planned_items_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_planned_items_user": {
+          "name": "idx_planned_items_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_planned_items_date_slot_order": {
+          "name": "idx_planned_items_date_slot_order",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_planned_items_recipe": {
+          "name": "idx_planned_items_recipe",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "planned_items_user_id_user_id_fk": {
+          "name": "planned_items_user_id_user_id_fk",
+          "tableFrom": "planned_items",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "planned_items_recipe_id_recipes_id_fk": {
+          "name": "planned_items_recipe_id_recipes_id_fk",
+          "tableFrom": "planned_items",
+          "tableTo": "recipes",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_groceries": {
+      "name": "recurring_groceries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_rule": {
+          "name": "recurrence_rule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recurrence_interval": {
+          "name": "recurrence_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "recurrence_weekday": {
+          "name": "recurrence_weekday",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_planned_for": {
+          "name": "next_planned_for",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_checked_date": {
+          "name": "last_checked_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "idx_recurring_groceries_user_id": {
+          "name": "idx_recurring_groceries_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_recurring_groceries_next_date": {
+          "name": "idx_recurring_groceries_next_date",
+          "columns": [
+            {
+              "expression": "next_planned_for",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recurring_groceries_user_id_user_id_fk": {
+          "name": "recurring_groceries_user_id_user_id_fk",
+          "tableFrom": "recurring_groceries",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingredient_store_preferences": {
+      "name": "ingredient_store_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "store_id": {
+          "name": "store_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "idx_ingredient_store_prefs_user_id": {
+          "name": "idx_ingredient_store_prefs_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ingredient_store_prefs_store_id": {
+          "name": "idx_ingredient_store_prefs_store_id",
+          "columns": [
+            {
+              "expression": "store_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingredient_store_preferences_user_id_user_id_fk": {
+          "name": "ingredient_store_preferences_user_id_user_id_fk",
+          "tableFrom": "ingredient_store_preferences",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ingredient_store_preferences_store_id_stores_id_fk": {
+          "name": "ingredient_store_preferences_store_id_stores_id_fk",
+          "tableFrom": "ingredient_store_preferences",
+          "tableTo": "stores",
+          "columnsFrom": [
+            "store_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_ingredient_store_prefs_user_name": {
+          "name": "uq_ingredient_store_prefs_user_name",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "normalized_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stores": {
+      "name": "stores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'primary'"
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ShoppingBagIcon'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "idx_stores_user_id": {
+          "name": "idx_stores_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_stores_sort_order": {
+          "name": "idx_stores_sort_order",
+          "columns": [
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stores_user_id_user_id_fk": {
+          "name": "stores_user_id_user_id_fk",
+          "tableFrom": "stores",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.server_config": {
+      "name": "server_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_enc": {
+          "name": "value_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_sensitive": {
+          "name": "is_sensitive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "server_config_key_idx": {
+          "name": "server_config_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "server_config_updated_by_user_id_fk": {
+          "name": "server_config_updated_by_user_id_fk",
+          "tableFrom": "server_config",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recipe_favorites": {
+      "name": "recipe_favorites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "idx_recipe_favorites_user_id": {
+          "name": "idx_recipe_favorites_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_recipe_favorites_recipe_id": {
+          "name": "idx_recipe_favorites_recipe_id",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recipe_favorites_user_id_user_id_fk": {
+          "name": "recipe_favorites_user_id_user_id_fk",
+          "tableFrom": "recipe_favorites",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recipe_favorites_recipe_id_recipes_id_fk": {
+          "name": "recipe_favorites_recipe_id_recipes_id_fk",
+          "tableFrom": "recipe_favorites",
+          "tableTo": "recipes",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_recipe_favorites_user_recipe": {
+          "name": "uq_recipe_favorites_user_recipe",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "recipe_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recipe_ratings": {
+      "name": "recipe_ratings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "idx_recipe_ratings_user_id": {
+          "name": "idx_recipe_ratings_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_recipe_ratings_recipe_id": {
+          "name": "idx_recipe_ratings_recipe_id",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recipe_ratings_user_id_user_id_fk": {
+          "name": "recipe_ratings_user_id_user_id_fk",
+          "tableFrom": "recipe_ratings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recipe_ratings_recipe_id_recipes_id_fk": {
+          "name": "recipe_ratings_recipe_id_recipes_id_fk",
+          "tableFrom": "recipe_ratings",
+          "tableTo": "recipes",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_recipe_ratings_user_recipe": {
+          "name": "uq_recipe_ratings_user_recipe",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "recipe_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recipe_shares": {
+      "name": "recipe_shares",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "idx_recipe_shares_user_id": {
+          "name": "idx_recipe_shares_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_recipe_shares_recipe_id": {
+          "name": "idx_recipe_shares_recipe_id",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recipe_shares_user_id_user_id_fk": {
+          "name": "recipe_shares_user_id_user_id_fk",
+          "tableFrom": "recipe_shares",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recipe_shares_recipe_id_recipes_id_fk": {
+          "name": "recipe_shares_recipe_id_recipes_id_fk",
+          "tableFrom": "recipe_shares",
+          "tableTo": "recipes",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_recipe_shares_token_hash": {
+          "name": "uq_recipe_shares_token_hash",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_allergies": {
+      "name": "user_allergies",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "idx_user_allergies_user_id": {
+          "name": "idx_user_allergies_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_allergies_tag_id": {
+          "name": "idx_user_allergies_tag_id",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_allergies_user_id_user_id_fk": {
+          "name": "user_allergies_user_id_user_id_fk",
+          "tableFrom": "user_allergies",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_allergies_tag_id_tags_id_fk": {
+          "name": "user_allergies_tag_id_tags_id_fk",
+          "tableFrom": "user_allergies",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "pk_user_allergies": {
+          "name": "pk_user_allergies",
+          "columns": [
+            "user_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.site_auth_tokens": {
+      "name": "site_auth_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_enc": {
+          "name": "value_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "site_auth_token_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "idx_site_auth_tokens_user_id": {
+          "name": "idx_site_auth_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_site_auth_tokens_user_domain": {
+          "name": "idx_site_auth_tokens_user_domain",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "site_auth_tokens_user_id_user_id_fk": {
+          "name": "site_auth_tokens_user_id_user_id_fk",
+          "tableFrom": "site_auth_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_logs": {
+      "name": "job_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "queue_name": {
+          "name": "queue_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "job_logs_queue_name_idx": {
+          "name": "job_logs_queue_name_idx",
+          "columns": [
+            {
+              "expression": "queue_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "job_logs_status_idx": {
+          "name": "job_logs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "job_logs_user_id_idx": {
+          "name": "job_logs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "job_logs_recipe_id_idx": {
+          "name": "job_logs_recipe_id_idx",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "job_logs_created_at_idx": {
+          "name": "job_logs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "job_logs_user_id_user_id_fk": {
+          "name": "job_logs_user_id_user_id_fk",
+          "tableFrom": "job_logs",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.caldav_item_type": {
+      "name": "caldav_item_type",
+      "schema": "public",
+      "values": [
+        "recipe",
+        "note"
+      ]
+    },
+    "public.caldav_sync_status_enum": {
+      "name": "caldav_sync_status_enum",
+      "schema": "public",
+      "values": [
+        "pending",
+        "synced",
+        "failed",
+        "removed"
+      ]
+    },
+    "public.measurement_system": {
+      "name": "measurement_system",
+      "schema": "public",
+      "values": [
+        "metric",
+        "us"
+      ]
+    },
+    "public.item_type": {
+      "name": "item_type",
+      "schema": "public",
+      "values": [
+        "recipe",
+        "note"
+      ]
+    },
+    "public.slot_type": {
+      "name": "slot_type",
+      "schema": "public",
+      "values": [
+        "Breakfast",
+        "Lunch",
+        "Dinner",
+        "Snack"
+      ]
+    },
+    "public.recipe_category": {
+      "name": "recipe_category",
+      "schema": "public",
+      "values": [
+        "Breakfast",
+        "Lunch",
+        "Dinner",
+        "Snack"
+      ]
+    },
+    "public.site_auth_token_type": {
+      "name": "site_auth_token_type",
+      "schema": "public",
+      "values": [
+        "header",
+        "cookie"
+      ]
+    },
+    "public.job_status": {
+      "name": "job_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "active",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.job_step_status": {
+      "name": "job_step_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "completed",
+        "failed",
+        "skipped"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -246,6 +246,13 @@
       "when": 1777204800000,
       "tag": "0034_loosen_step_order_constraint",
       "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "7",
+      "when": 1746380000000,
+      "tag": "0035_add_job_logs",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/repositories/index.ts
+++ b/packages/db/src/repositories/index.ts
@@ -16,3 +16,4 @@ export * from "@norish/db/repositories/user-allergies";
 export * from "@norish/db/repositories/planned-items";
 export * from "@norish/db/repositories/site-auth-tokens";
 export * from "@norish/db/repositories/recipe-shares";
+export * from "@norish/db/repositories/job-logs";

--- a/packages/db/src/repositories/job-logs.ts
+++ b/packages/db/src/repositories/job-logs.ts
@@ -1,0 +1,198 @@
+import { and, desc, eq, gte, inArray, lte, sql } from "drizzle-orm";
+
+import type { JobStepRecord, NewJobLog } from "../schema/job-logs";
+import { db } from "../drizzle";
+import { jobLogs } from "../schema/job-logs";
+
+/**
+ * Create a new job log entry when a job is queued.
+ */
+export async function createJobLog(data: NewJobLog): Promise<string> {
+  const [row] = await db.insert(jobLogs).values(data).returning({ id: jobLogs.id });
+
+  return row!.id;
+}
+
+/**
+ * Mark a job as active (started processing).
+ */
+export async function markJobActive(id: string): Promise<void> {
+  await db
+    .update(jobLogs)
+    .set({ status: "active", startedAt: new Date() })
+    .where(eq(jobLogs.id, id));
+}
+
+/**
+ * Mark a job as completed.
+ */
+export async function markJobCompleted(
+  id: string,
+  result?: unknown
+): Promise<void> {
+  await db
+    .update(jobLogs)
+    .set({
+      status: "completed",
+      completedAt: new Date(),
+      result: result ?? null,
+    })
+    .where(eq(jobLogs.id, id));
+}
+
+/**
+ * Mark a job as failed.
+ */
+export async function markJobFailed(id: string, error: string): Promise<void> {
+  await db
+    .update(jobLogs)
+    .set({
+      status: "failed",
+      completedAt: new Date(),
+      error,
+    })
+    .where(eq(jobLogs.id, id));
+}
+
+/**
+ * Update the steps array for a job log.
+ */
+export async function updateJobSteps(
+  id: string,
+  steps: JobStepRecord[]
+): Promise<void> {
+  await db.update(jobLogs).set({ steps }).where(eq(jobLogs.id, id));
+}
+
+/**
+ * Set the AI model used for a job.
+ */
+export async function setJobAiModel(id: string, aiModel: string): Promise<void> {
+  await db.update(jobLogs).set({ aiModel }).where(eq(jobLogs.id, id));
+}
+
+/**
+ * List job logs with pagination and optional filters.
+ */
+export async function listJobLogs(options: {
+  limit?: number;
+  offset?: number;
+  queueName?: string;
+  status?: string;
+  userId?: string;
+  fromDate?: Date;
+  toDate?: Date;
+}): Promise<{ jobs: typeof jobLogs.$inferSelect[]; total: number }> {
+  const {
+    limit = 20,
+    offset = 0,
+    queueName,
+    status,
+    userId,
+    fromDate,
+    toDate,
+  } = options;
+
+  const conditions = [];
+
+  if (queueName) conditions.push(eq(jobLogs.queueName, queueName));
+  if (status) conditions.push(eq(jobLogs.status, status as any));
+  if (userId) conditions.push(eq(jobLogs.userId, userId));
+  if (fromDate) conditions.push(gte(jobLogs.createdAt, fromDate));
+  if (toDate) conditions.push(lte(jobLogs.createdAt, toDate));
+
+  const where = conditions.length > 0 ? and(...conditions) : undefined;
+
+  const [jobs, countResult] = await Promise.all([
+    db
+      .select()
+      .from(jobLogs)
+      .where(where)
+      .orderBy(desc(jobLogs.createdAt))
+      .limit(limit)
+      .offset(offset),
+    db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(jobLogs)
+      .where(where),
+  ]);
+
+  return { jobs, total: countResult[0]?.count ?? 0 };
+}
+
+/**
+ * Get a single job log by ID.
+ */
+export async function getJobLog(id: string) {
+  const [row] = await db.select().from(jobLogs).where(eq(jobLogs.id, id)).limit(1);
+
+  return row ?? null;
+}
+
+/**
+ * Get job stats (counts by status and queue).
+ */
+export async function getJobStats(): Promise<{
+  byStatus: Record<string, number>;
+  byQueue: Record<string, number>;
+}> {
+  const [statusCounts, queueCounts] = await Promise.all([
+    db
+      .select({
+        status: jobLogs.status,
+        count: sql<number>`count(*)::int`,
+      })
+      .from(jobLogs)
+      .groupBy(jobLogs.status),
+    db
+      .select({
+        queueName: jobLogs.queueName,
+        count: sql<number>`count(*)::int`,
+      })
+      .from(jobLogs)
+      .groupBy(jobLogs.queueName),
+  ]);
+
+  const byStatus: Record<string, number> = {};
+
+  for (const row of statusCounts) {
+    byStatus[row.status] = row.count;
+  }
+
+  const byQueue: Record<string, number> = {};
+
+  for (const row of queueCounts) {
+    byQueue[row.queueName] = row.count;
+  }
+
+  return { byStatus, byQueue };
+}
+
+/**
+ * Delete job logs older than the given date.
+ * Used by the scheduled cleanup task.
+ */
+export async function deleteOldJobLogs(olderThan: Date): Promise<number> {
+  const result = await db
+    .delete(jobLogs)
+    .where(lte(jobLogs.createdAt, olderThan))
+    .returning({ id: jobLogs.id });
+
+  return result.length;
+}
+
+/**
+ * Find a job log by BullMQ job ID and queue name.
+ */
+export async function findJobLogByJobId(
+  jobId: string,
+  queueName: string
+) {
+  const [row] = await db
+    .select()
+    .from(jobLogs)
+    .where(and(eq(jobLogs.jobId, jobId), eq(jobLogs.queueName, queueName)))
+    .limit(1);
+
+  return row ?? null;
+}

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -26,3 +26,4 @@ export * from "./recipe-ratings";
 export * from "./recipe-shares";
 export * from "./user-allergies";
 export * from "./site-auth-tokens";
+export * from "./job-logs";

--- a/packages/db/src/schema/job-logs.ts
+++ b/packages/db/src/schema/job-logs.ts
@@ -1,0 +1,96 @@
+import crypto from "crypto";
+import { index, jsonb, pgEnum, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+import { users } from "./auth";
+
+/**
+ * Job status enum for background queue jobs.
+ */
+export const jobStatusEnum = pgEnum("job_status", [
+  "queued",
+  "active",
+  "completed",
+  "failed",
+]);
+
+/**
+ * Step status enum for individual job steps.
+ */
+export const jobStepStatusEnum = pgEnum("job_step_status", [
+  "pending",
+  "active",
+  "completed",
+  "failed",
+  "skipped",
+]);
+
+/**
+ * Persistent job logs for background queue processing.
+ *
+ * Stores a record of every background job with its steps,
+ * inputs, outputs, errors, and timing information.
+ * Used by the admin UI to inspect current and past jobs.
+ */
+export const jobLogs = pgTable(
+  "job_logs",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    /** BullMQ job ID */
+    jobId: text("job_id").notNull(),
+    /** Queue name (e.g. "recipe-import", "image-recipe-import") */
+    queueName: text("queue_name").notNull(),
+    /** Current job status */
+    status: jobStatusEnum("status").notNull().default("queued"),
+    /** User who triggered the job */
+    userId: text("user_id").references(() => users.id, { onDelete: "set null" }),
+    /** Associated recipe ID (if applicable) */
+    recipeId: text("recipe_id"),
+    /** Human-readable job description (e.g. URL, filename) */
+    description: text("description"),
+    /** Job input data (sanitized - no secrets) */
+    input: jsonb("input"),
+    /**
+     * Steps array - each step is:
+     * { name: string, status: string, startedAt?: string, completedAt?: string, output?: any, error?: string }
+     */
+    steps: jsonb("steps").$type<JobStepRecord[]>().default([]),
+    /** Final result/output summary */
+    result: jsonb("result"),
+    /** Error message if job failed */
+    error: text("error"),
+    /** AI model used (if applicable) */
+    aiModel: text("ai_model"),
+    /** When the job started processing */
+    startedAt: timestamp("started_at", { withTimezone: true }),
+    /** When the job finished (success or failure) */
+    completedAt: timestamp("completed_at", { withTimezone: true }),
+    /** When the job was created/queued */
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    index("job_logs_queue_name_idx").on(t.queueName),
+    index("job_logs_status_idx").on(t.status),
+    index("job_logs_user_id_idx").on(t.userId),
+    index("job_logs_recipe_id_idx").on(t.recipeId),
+    index("job_logs_created_at_idx").on(t.createdAt),
+  ]
+);
+
+/**
+ * Type for a single step record stored in the steps JSONB column.
+ */
+export interface JobStepRecord {
+  name: string;
+  status: "pending" | "active" | "completed" | "failed" | "skipped";
+  startedAt?: string;
+  completedAt?: string;
+  /** Step output/data (kept small - summaries, not full payloads) */
+  output?: unknown;
+  /** Error message if step failed */
+  error?: string;
+}
+
+export type JobLog = typeof jobLogs.$inferSelect;
+export type NewJobLog = typeof jobLogs.$inferInsert;

--- a/packages/i18n/src/messages/en/navbar.json
+++ b/packages/i18n/src/messages/en/navbar.json
@@ -46,5 +46,11 @@
     "skipped": "{count} skipped",
     "errors": "{count} errors",
     "ofTotal": "{current} of {total}"
+  },
+  "jobs": {
+    "title": "Jobs",
+    "empty": "No recent jobs",
+    "viewAll": "View all jobs",
+    "active": "{count} active"
   }
 }

--- a/packages/i18n/src/messages/en/settings.json
+++ b/packages/i18n/src/messages/en/settings.json
@@ -624,6 +624,75 @@
       "invalidJson": "Invalid JSON format",
       "failedToSave": "Failed to save",
       "failedToRestore": "Failed to restore defaults"
+    },
+    "jobs": {
+      "title": "Job Queue",
+      "description": "Monitor background processing jobs",
+      "empty": "No jobs found",
+      "filters": {
+        "allQueues": "All Queues",
+        "allStatuses": "All Statuses"
+      },
+      "status": {
+        "queued": "Queued",
+        "active": "In Progress",
+        "completed": "Completed",
+        "failed": "Failed"
+      },
+      "stepStatus": {
+        "pending": "Pending",
+        "active": "Running",
+        "completed": "Done",
+        "failed": "Failed",
+        "skipped": "Skipped"
+      },
+      "queues": {
+        "recipe-import": "Recipe Import",
+        "image-recipe-import": "Image Import",
+        "paste-recipe-import": "Paste Import",
+        "caldav-sync": "CalDAV Sync",
+        "scheduled-tasks": "Scheduled Tasks",
+        "nutrition-estimation": "Nutrition",
+        "auto-tagging": "Auto Tagging",
+        "auto-categorization": "Auto Categorization",
+        "allergy-detection": "Allergy Detection"
+      },
+      "detail": {
+        "title": "Job Details",
+        "jobId": "Job ID",
+        "queue": "Queue",
+        "status": "Status",
+        "user": "User",
+        "recipe": "Recipe",
+        "description": "Description",
+        "aiModel": "AI Model",
+        "startedAt": "Started",
+        "completedAt": "Finished",
+        "createdAt": "Created",
+        "duration": "Duration",
+        "error": "Error",
+        "steps": "Pipeline Steps",
+        "input": "Input",
+        "result": "Result"
+      },
+      "stats": {
+        "total": "Total",
+        "active": "Active",
+        "completed": "Completed",
+        "failed": "Failed"
+      },
+      "actions": {
+        "purge": "Purge Old Jobs",
+        "purgeConfirm": "Delete jobs older than {days} days?",
+        "purged": "Deleted {count} old job(s)",
+        "refresh": "Refresh",
+        "viewDetails": "View Details"
+      },
+      "pagination": {
+        "showing": "Showing {from}-{to} of {total}",
+        "next": "Next",
+        "previous": "Previous"
+      }
     }
   }
 }

--- a/packages/queue/src/image-import/worker.ts
+++ b/packages/queue/src/image-import/worker.ts
@@ -48,6 +48,7 @@ export async function processImageImportJob(job: Job<ImageImportJobData>): Promi
     description: `${files.length} image(s)`,
     input: { fileCount: files.length, filenames: files.map((f) => f.filename) },
     steps: ["fetch_allergies", "ai_extraction", "save_recipe", "save_image", "emit_result"],
+    attempt: job.attemptsMade + 1,
   });
 
   const policy = await getRecipePermissionPolicy();

--- a/packages/queue/src/image-import/worker.ts
+++ b/packages/queue/src/image-import/worker.ts
@@ -25,6 +25,7 @@ import { emitByPolicy } from "@norish/trpc/helpers";
 import { recipeEmitter } from "@norish/trpc/routers/recipes/emitter";
 
 import { baseWorkerOptions, QUEUE_NAMES, STALLED_INTERVAL, WORKER_CONCURRENCY } from "../config";
+import { JobLogger } from "../job-logger";
 import { createLazyWorker, stopLazyWorker } from "../lazy-worker-manager";
 
 const log = createLogger("worker:image-import");
@@ -38,6 +39,17 @@ export async function processImageImportJob(job: Job<ImageImportJobData>): Promi
 
   log.info({ jobId: job.id, recipeId, fileCount: files.length }, "Processing image import job");
 
+  // Create job logger
+  const jobLogger = await JobLogger.create({
+    jobId: job.id!,
+    queueName: QUEUE_NAMES.IMAGE_IMPORT,
+    userId,
+    recipeId,
+    description: `${files.length} image(s)`,
+    input: { fileCount: files.length, filenames: files.map((f) => f.filename) },
+    steps: ["fetch_allergies", "ai_extraction", "save_recipe", "save_image", "emit_result"],
+  });
+
   const policy = await getRecipePermissionPolicy();
   const viewPolicy = policy.view;
   const ctx: PolicyEmitContext = { userId, householdKey };
@@ -48,7 +60,8 @@ export async function processImageImportJob(job: Job<ImageImportJobData>): Promi
     url: `[${files.length} image(s)]`,
   });
 
-  // Fetch household allergies for targeted allergy detection
+  // Step 1: Fetch household allergies
+  await jobLogger.startStep("fetch_allergies");
   const aiConfig = await getAIConfig();
   let allergyNames: string[] | undefined;
 
@@ -60,63 +73,80 @@ export async function processImageImportJob(job: Job<ImageImportJobData>): Promi
       { allergyCount: allergyNames.length },
       "Fetched household allergies for image import"
     );
+    await jobLogger.completeStep("fetch_allergies", { allergyCount: allergyNames.length });
+  } else {
+    await jobLogger.skipStep("fetch_allergies", "autoTagAllergies disabled");
   }
 
-  // Extract recipe from images using AI vision
+  // Step 2: AI extraction from images
+  await jobLogger.startStep("ai_extraction");
+  if (aiConfig?.model) {
+    await jobLogger.setAiModel(aiConfig.model);
+  }
+
   const result = await extractRecipeFromImages(recipeId, files, allergyNames);
 
   if (!result.success) {
-    throw new Error(
-      result.error ||
-        "Failed to extract recipe from images. The images may not contain a valid recipe."
-    );
+    const errorMsg = result.error || "Failed to extract recipe from images.";
+    await jobLogger.failStep("ai_extraction", errorMsg);
+    await jobLogger.fail(errorMsg);
+    throw new Error(errorMsg);
   }
 
   const parsedRecipe = result.data;
+  await jobLogger.completeStep("ai_extraction", { title: parsedRecipe.title });
 
-  // Save the recipe
+  // Step 3: Save the recipe
+  await jobLogger.startStep("save_recipe");
   const createdId = await createRecipeWithRefs(recipeId, userId, parsedRecipe);
 
   if (!createdId) {
+    await jobLogger.failStep("save_recipe", "Failed to save imported recipe");
+    await jobLogger.fail("Failed to save imported recipe");
     throw new Error("Failed to save imported recipe");
   }
+  await jobLogger.completeStep("save_recipe", { createdRecipeId: createdId });
 
-  // Save the first uploaded image as the recipe image
+  // Step 4: Save uploaded image as recipe image
+  await jobLogger.startStep("save_image");
   if (files.length > 0) {
     const firstFile = files[0];
 
-    if (!firstFile) {
-      return;
-    }
+    if (firstFile) {
+      try {
+        const imageBytes = Buffer.from(firstFile.data, "base64");
+        const imagePath = await saveImageBytes(imageBytes, recipeId);
 
-    try {
-      const imageBytes = Buffer.from(firstFile.data, "base64");
-      const imagePath = await saveImageBytes(imageBytes, recipeId);
-
-      await addRecipeImages(createdId, [{ image: imagePath, order: 0 }]);
-      log.debug({ recipeId: createdId }, "Saved first uploaded image as recipe image");
-    } catch (imageError) {
-      // Log but don't fail the import if image saving fails
-      log.warn({ err: imageError, recipeId: createdId }, "Failed to save uploaded image");
+        await addRecipeImages(createdId, [{ image: imagePath, order: 0 }]);
+        log.debug({ recipeId: createdId }, "Saved first uploaded image as recipe image");
+        await jobLogger.completeStep("save_image", { imagePath });
+      } catch (imageError) {
+        log.warn({ err: imageError, recipeId: createdId }, "Failed to save uploaded image");
+        await jobLogger.failStep("save_image", "Failed to save uploaded image (non-fatal)");
+      }
+    } else {
+      await jobLogger.skipStep("save_image", "No valid file");
     }
+  } else {
+    await jobLogger.skipStep("save_image", "No files provided");
   }
 
+  // Step 5: Emit result
+  await jobLogger.startStep("emit_result");
   const dashboardDto = await dashboardRecipe(createdId);
 
   if (dashboardDto) {
     log.info({ jobId: job.id, recipeId: createdId }, "Image recipe imported successfully");
 
-    // Emit imported event (replaces skeleton with actual recipe)
-    // Image import is always AI-based, so no processing will follow - show imported toast
     emitByPolicy(recipeEmitter, viewPolicy, ctx, "imported", {
       recipe: dashboardDto,
       pendingRecipeId: recipeId,
       toast: "imported",
     });
-
-    // Note: No auto-tagging job queued - image import is always AI-based,
-    // and AI extraction prompts already include auto-tagging instructions
   }
+
+  await jobLogger.completeStep("emit_result");
+  await jobLogger.complete({ recipeId: createdId, title: parsedRecipe.title });
 }
 
 /**

--- a/packages/queue/src/index.ts
+++ b/packages/queue/src/index.ts
@@ -21,6 +21,7 @@ export {
 // Helpers
 export { generateJobId, isJobInQueue } from "./helpers";
 export { createOperationAwareQueue } from "./operation-aware-queue";
+export { JobLogger } from "./job-logger";
 
 // Registry - centralized lifecycle
 export { initializeQueues, getQueues, closeAllQueues } from "./registry";

--- a/packages/queue/src/job-logger.ts
+++ b/packages/queue/src/job-logger.ts
@@ -67,15 +67,35 @@ export class JobLogger {
   }
 
   /**
-   * Create a new job log and mark it as active.
+   * Create a new job log (or reuse existing one for retried jobs) and mark it as active.
    */
-  static async create(options: JobLoggerOptions): Promise<JobLogger> {
+  static async create(options: JobLoggerOptions & { attempt?: number }): Promise<JobLogger> {
     const steps: JobStepRecord[] = options.steps.map((name) => ({
       name,
       status: "pending",
     }));
 
     try {
+      // For retried jobs (attempt > 1), find and reuse the existing log entry
+      if (options.attempt && options.attempt > 1) {
+        const { findJobLogByJobId, markJobActive: reactivate, updateJobSteps: resetSteps } =
+          await import("@norish/db/repositories/job-logs");
+        const existing = await findJobLogByJobId(options.jobId, options.queueName);
+
+        if (existing) {
+          // Reset the log for the new attempt
+          await reactivate(existing.id);
+          await resetSteps(existing.id, steps);
+
+          log.debug(
+            { logId: existing.id, queueName: options.queueName, attempt: options.attempt },
+            "Reusing existing job log for retry"
+          );
+
+          return new JobLogger(existing.id, steps, options.queueName);
+        }
+      }
+
       const logId = await createJobLog({
         jobId: options.jobId,
         queueName: options.queueName,

--- a/packages/queue/src/job-logger.ts
+++ b/packages/queue/src/job-logger.ts
@@ -1,0 +1,242 @@
+/**
+ * Job Logger
+ *
+ * Utility for tracking job execution steps in the database.
+ * Workers use this to create a persistent, inspectable record
+ * of each job's processing pipeline.
+ *
+ * Usage:
+ * ```ts
+ * const logger = await JobLogger.create({
+ *   jobId: job.id!,
+ *   queueName: "recipe-import",
+ *   userId: job.data.userId,
+ *   recipeId: job.data.recipeId,
+ *   description: job.data.url,
+ *   input: { url: job.data.url },
+ *   steps: ["fetch_url", "parse_recipe", "save_recipe"],
+ * });
+ *
+ * await logger.startStep("fetch_url");
+ * // ... do work
+ * await logger.completeStep("fetch_url", { bytesDownloaded: 1234 });
+ *
+ * await logger.complete({ recipeId: "abc" });
+ * ```
+ */
+
+import type { JobStepRecord } from "@norish/db/schema/job-logs";
+import {
+  createJobLog,
+  markJobActive,
+  markJobCompleted,
+  markJobFailed,
+  setJobAiModel,
+  updateJobSteps,
+} from "@norish/db/repositories/job-logs";
+import { createLogger } from "@norish/shared-server/logger";
+
+const log = createLogger("job-logger");
+
+export interface JobLoggerOptions {
+  /** BullMQ job ID */
+  jobId: string;
+  /** Queue name */
+  queueName: string;
+  /** User who triggered the job */
+  userId: string;
+  /** Associated recipe ID (if applicable) */
+  recipeId?: string;
+  /** Human-readable description (URL, filename, etc.) */
+  description?: string;
+  /** Sanitized input data */
+  input?: Record<string, unknown>;
+  /** Ordered list of step names for this job type */
+  steps: string[];
+}
+
+export class JobLogger {
+  private logId: string;
+  private steps: JobStepRecord[];
+  private queueName: string;
+
+  private constructor(logId: string, steps: JobStepRecord[], queueName: string) {
+    this.logId = logId;
+    this.steps = steps;
+    this.queueName = queueName;
+  }
+
+  /**
+   * Create a new job log and mark it as active.
+   */
+  static async create(options: JobLoggerOptions): Promise<JobLogger> {
+    const steps: JobStepRecord[] = options.steps.map((name) => ({
+      name,
+      status: "pending",
+    }));
+
+    try {
+      const logId = await createJobLog({
+        jobId: options.jobId,
+        queueName: options.queueName,
+        userId: options.userId,
+        recipeId: options.recipeId ?? null,
+        description: options.description ?? null,
+        input: options.input ?? null,
+        steps,
+        status: "active",
+        startedAt: new Date(),
+      });
+
+      log.debug(
+        { logId, queueName: options.queueName, jobId: options.jobId },
+        "Job log created"
+      );
+
+      return new JobLogger(logId, steps, options.queueName);
+    } catch (err) {
+      // Don't let logging failures break job processing
+      log.error({ err, queueName: options.queueName }, "Failed to create job log");
+
+      // Return a no-op logger
+      return new JobLogger("", steps, options.queueName);
+    }
+  }
+
+  /** Get the database log ID */
+  get id(): string {
+    return this.logId;
+  }
+
+  /**
+   * Mark a step as active (started).
+   */
+  async startStep(stepName: string): Promise<void> {
+    if (!this.logId) return;
+
+    const step = this.steps.find((s) => s.name === stepName);
+
+    if (step) {
+      step.status = "active";
+      step.startedAt = new Date().toISOString();
+      await this.persistSteps();
+    }
+  }
+
+  /**
+   * Mark a step as completed with optional output data.
+   */
+  async completeStep(stepName: string, output?: unknown): Promise<void> {
+    if (!this.logId) return;
+
+    const step = this.steps.find((s) => s.name === stepName);
+
+    if (step) {
+      step.status = "completed";
+      step.completedAt = new Date().toISOString();
+      if (output !== undefined) step.output = output;
+      await this.persistSteps();
+    }
+  }
+
+  /**
+   * Mark a step as failed with an error message.
+   */
+  async failStep(stepName: string, error: string): Promise<void> {
+    if (!this.logId) return;
+
+    const step = this.steps.find((s) => s.name === stepName);
+
+    if (step) {
+      step.status = "failed";
+      step.completedAt = new Date().toISOString();
+      step.error = error;
+      await this.persistSteps();
+    }
+  }
+
+  /**
+   * Mark a step as skipped (e.g. when a condition isn't met).
+   */
+  async skipStep(stepName: string, reason?: string): Promise<void> {
+    if (!this.logId) return;
+
+    const step = this.steps.find((s) => s.name === stepName);
+
+    if (step) {
+      step.status = "skipped";
+      step.completedAt = new Date().toISOString();
+      if (reason) step.output = { reason };
+      await this.persistSteps();
+    }
+  }
+
+  /**
+   * Record which AI model was used.
+   */
+  async setAiModel(model: string): Promise<void> {
+    if (!this.logId) return;
+
+    try {
+      await setJobAiModel(this.logId, model);
+    } catch (err) {
+      log.error({ err, logId: this.logId }, "Failed to set AI model");
+    }
+  }
+
+  /**
+   * Mark the job as completed with optional result summary.
+   */
+  async complete(result?: unknown): Promise<void> {
+    if (!this.logId) return;
+
+    // Mark any remaining pending steps as skipped
+    for (const step of this.steps) {
+      if (step.status === "pending") {
+        step.status = "skipped";
+      }
+    }
+
+    try {
+      await this.persistSteps();
+      await markJobCompleted(this.logId, result);
+      log.debug({ logId: this.logId, queueName: this.queueName }, "Job log completed");
+    } catch (err) {
+      log.error({ err, logId: this.logId }, "Failed to complete job log");
+    }
+  }
+
+  /**
+   * Mark the job as failed.
+   */
+  async fail(error: string): Promise<void> {
+    if (!this.logId) return;
+
+    // Mark any active/pending steps as failed
+    for (const step of this.steps) {
+      if (step.status === "active") {
+        step.status = "failed";
+        step.completedAt = new Date().toISOString();
+        step.error = error;
+      } else if (step.status === "pending") {
+        step.status = "skipped";
+      }
+    }
+
+    try {
+      await this.persistSteps();
+      await markJobFailed(this.logId, error);
+      log.debug({ logId: this.logId, queueName: this.queueName }, "Job log failed");
+    } catch (err) {
+      log.error({ err, logId: this.logId }, "Failed to mark job log as failed");
+    }
+  }
+
+  private async persistSteps(): Promise<void> {
+    try {
+      await updateJobSteps(this.logId, this.steps);
+    } catch (err) {
+      log.error({ err, logId: this.logId }, "Failed to persist job steps");
+    }
+  }
+}

--- a/packages/queue/src/paste-import/worker.ts
+++ b/packages/queue/src/paste-import/worker.ts
@@ -35,6 +35,7 @@ import { emitByPolicy } from "@norish/trpc/helpers";
 import { recipeEmitter } from "@norish/trpc/routers/recipes/emitter";
 
 import { baseWorkerOptions, QUEUE_NAMES, STALLED_INTERVAL, WORKER_CONCURRENCY } from "../config";
+import { JobLogger } from "../job-logger";
 import { createLazyWorker, stopLazyWorker } from "../lazy-worker-manager";
 
 const log = createLogger("worker:paste-import");
@@ -156,6 +157,26 @@ export async function processPasteImportJob(
     "Processing paste import job"
   );
 
+  const isStructured = structuredRecipes && structuredRecipes.length > 0;
+
+  // Create job logger
+  const jobLogger = await JobLogger.create({
+    jobId: job.id!,
+    queueName: QUEUE_NAMES.PASTE_IMPORT,
+    userId,
+    recipeId: recipeIds[0],
+    description: isStructured
+      ? `${structuredRecipes.length} structured recipe(s)`
+      : "[pasted text]",
+    input: {
+      recipeCount: recipeIds.length,
+      isStructured,
+      textLength: text?.length ?? 0,
+      forceAI: forceAI ?? false,
+    },
+    steps: ["fetch_allergies", "parse_recipes", "save_recipes", "post_processing"],
+  });
+
   const policy = await getRecipePermissionPolicy();
   const viewPolicy = policy.view;
   const ctx: PolicyEmitContext = { userId, householdKey };
@@ -167,6 +188,8 @@ export async function processPasteImportJob(
     });
   });
 
+  // Step 1: Fetch allergies
+  await jobLogger.startStep("fetch_allergies");
   const aiConfig = await getAIConfig();
   let allergyNames: string[] | undefined;
 
@@ -174,15 +197,20 @@ export async function processPasteImportJob(
     const householdAllergies = await getAllergiesForUsers(householdUserIds ?? [userId]);
 
     allergyNames = [...new Set(householdAllergies.map((a) => a.tagName))];
-    log.debug(
-      { allergyCount: allergyNames.length },
-      "Fetched household allergies for paste import"
-    );
+    await jobLogger.completeStep("fetch_allergies", { allergyCount: allergyNames.length });
+  } else {
+    await jobLogger.skipStep("fetch_allergies", "autoTagAllergies disabled");
   }
 
+  // Step 2: Parse recipes
+  await jobLogger.startStep("parse_recipes");
   const createdRecipeIds: string[] = [];
 
-  if (structuredRecipes && structuredRecipes.length > 0) {
+  if (isStructured) {
+    // Step 3: Save structured recipes
+    await jobLogger.completeStep("parse_recipes", { mode: "structured", count: structuredRecipes.length });
+    await jobLogger.startStep("save_recipes");
+
     for (const structuredRecipe of structuredRecipes) {
       const createdId = await createStructuredRecipe(structuredRecipe, userId, householdKey);
 
@@ -194,25 +222,44 @@ export async function processPasteImportJob(
     }
 
     if (createdRecipeIds.length === 0) {
+      await jobLogger.failStep("save_recipes", "No valid recipes found in structured paste input.");
+      await jobLogger.fail("No valid recipes found in structured paste input.");
       throw new Error("No valid recipes found in structured paste input.");
     }
+
+    await jobLogger.completeStep("save_recipes", { createdCount: createdRecipeIds.length });
   } else {
     const recipeId = recipeIds[0];
 
     if (!recipeId) {
+      await jobLogger.failStep("parse_recipes", "Missing recipe ID");
+      await jobLogger.fail("Missing recipe ID for paste import.");
       throw new Error("Missing recipe ID for paste import.");
     }
 
+    if (aiConfig?.model) {
+      await jobLogger.setAiModel(aiConfig.model);
+    }
+
     const parseResult = await parseFromPastedText(text, recipeId, allergyNames, forceAI);
+    await jobLogger.completeStep("parse_recipes", { mode: "ai", title: parseResult.recipe.title });
+
+    // Step 3: Save recipe
+    await jobLogger.startStep("save_recipes");
     const createdId = await createRecipeWithRefs(recipeId, userId, parseResult.recipe);
 
     if (!createdId) {
+      await jobLogger.failStep("save_recipes", "Failed to save imported recipe");
+      await jobLogger.fail("Failed to save imported recipe");
       throw new Error("Failed to save imported recipe");
     }
 
     createdRecipeIds.push(createdId);
+    await jobLogger.completeStep("save_recipes", { createdRecipeId: createdId });
   }
 
+  // Step 4: Post-processing
+  await jobLogger.startStep("post_processing");
   const queues = getQueues();
 
   for (const createdId of createdRecipeIds) {
@@ -222,7 +269,7 @@ export async function processPasteImportJob(
       continue;
     }
 
-    const usedAI = !structuredRecipes || structuredRecipes.length === 0;
+    const usedAI = !isStructured;
 
     log.info({ jobId: job.id, recipeId: createdId, usedAI }, "Pasted recipe imported successfully");
 
@@ -246,6 +293,9 @@ export async function processPasteImportJob(
       });
     }
   }
+
+  await jobLogger.completeStep("post_processing", { recipeCount: createdRecipeIds.length });
+  await jobLogger.complete({ recipeIds: createdRecipeIds });
 
   return { recipeIds: createdRecipeIds };
 }

--- a/packages/queue/src/paste-import/worker.ts
+++ b/packages/queue/src/paste-import/worker.ts
@@ -175,6 +175,7 @@ export async function processPasteImportJob(
       forceAI: forceAI ?? false,
     },
     steps: ["fetch_allergies", "parse_recipes", "save_recipes", "post_processing"],
+    attempt: job.attemptsMade + 1,
   });
 
   const policy = await getRecipePermissionPolicy();

--- a/packages/queue/src/paste-import/worker.ts
+++ b/packages/queue/src/paste-import/worker.ts
@@ -242,7 +242,15 @@ export async function processPasteImportJob(
       await jobLogger.setAiModel(aiConfig.model);
     }
 
-    const parseResult = await parseFromPastedText(text, recipeId, allergyNames, forceAI);
+    const parseResult = await parseFromPastedText(text, recipeId, allergyNames, forceAI).catch(
+      async (err) => {
+        const msg = err instanceof Error ? err.message : "Failed to parse pasted recipe";
+
+        await jobLogger.failStep("parse_recipes", msg);
+        await jobLogger.fail(msg);
+        throw err;
+      }
+    );
     await jobLogger.completeStep("parse_recipes", { mode: "ai", title: parseResult.recipe.title });
 
     // Step 3: Save recipe

--- a/packages/queue/src/recipe-import/worker.ts
+++ b/packages/queue/src/recipe-import/worker.ts
@@ -36,6 +36,7 @@ import {
   WORKER_CONCURRENCY,
 } from "../config";
 import { withTimeout } from "../helpers";
+import { JobLogger } from "../job-logger";
 import { createLazyWorker, stopLazyWorker } from "../lazy-worker-manager";
 
 const log = createLogger("worker:recipe-import");
@@ -53,6 +54,17 @@ async function processImportJob(job: Job<RecipeImportJobData>): Promise<void> {
     "Processing recipe import job"
   );
 
+  // Create job logger for step tracking
+  const jobLogger = await JobLogger.create({
+    jobId: job.id!,
+    queueName: QUEUE_NAMES.RECIPE_IMPORT,
+    userId,
+    recipeId,
+    description: url,
+    input: { url, forceAI: job.data.forceAI ?? false },
+    steps: ["check_existing", "fetch_allergies", "parse_recipe", "save_recipe", "post_processing"],
+  });
+
   const policy = await getRecipePermissionPolicy();
   const viewPolicy = policy.view;
   const ctx: PolicyEmitContext = { userId, householdKey };
@@ -60,7 +72,8 @@ async function processImportJob(job: Job<RecipeImportJobData>): Promise<void> {
   // Emit import started event
   emitByPolicy(recipeEmitter, viewPolicy, ctx, "importStarted", { recipeId, url });
 
-  // Check if recipe already exists (policy-aware)
+  // Step 1: Check if recipe already exists (policy-aware)
+  await jobLogger.startStep("check_existing");
   const existingCheck = await recipeExistsByUrlForPolicy(url, userId, householdUserIds, viewPolicy);
 
   if (existingCheck.exists && existingCheck.existingRecipeId) {
@@ -72,8 +85,6 @@ async function processImportJob(job: Job<RecipeImportJobData>): Promise<void> {
         "Recipe already exists, returning existing"
       );
 
-      // Include pendingRecipeId so client can remove the skeleton
-      // Show imported toast since no processing will follow for existing recipes
       emitByPolicy(recipeEmitter, viewPolicy, ctx, "imported", {
         recipe: dashboardDto,
         pendingRecipeId: recipeId,
@@ -81,10 +92,19 @@ async function processImportJob(job: Job<RecipeImportJobData>): Promise<void> {
       });
     }
 
+    await jobLogger.completeStep("check_existing", {
+      alreadyExists: true,
+      existingRecipeId: existingCheck.existingRecipeId,
+    });
+    await jobLogger.complete({ result: "already_exists", existingRecipeId: existingCheck.existingRecipeId });
+
     return;
   }
 
-  // Fetch household allergies for targeted allergy detection (only if autoTagAllergies is enabled)
+  await jobLogger.completeStep("check_existing", { alreadyExists: false });
+
+  // Step 2: Fetch household allergies
+  await jobLogger.startStep("fetch_allergies");
   const aiConfig = await getAIConfig();
   let allergyNames: string[] | undefined;
 
@@ -96,11 +116,14 @@ async function processImportJob(job: Job<RecipeImportJobData>): Promise<void> {
       { allergyCount: allergyNames.length, allergies: allergyNames },
       "Fetched household allergies"
     );
+    await jobLogger.completeStep("fetch_allergies", { allergyCount: allergyNames.length, allergies: allergyNames });
   } else {
     log.debug("Auto-tag allergies disabled, skipping allergy detection");
+    await jobLogger.skipStep("fetch_allergies", "autoTagAllergies disabled");
   }
 
-  // Parse and create recipe
+  // Step 3: Parse recipe from URL
+  await jobLogger.startStep("parse_recipe");
   const userTokens = await getDecryptedTokensByUserId(userId);
   const parseResult = await withTimeout(
     () =>
@@ -117,15 +140,34 @@ async function processImportJob(job: Job<RecipeImportJobData>): Promise<void> {
 
   log.debug({ parseResult }, "Recipe parse result");
   if (!parseResult.recipe) {
+    await jobLogger.failStep("parse_recipe", "Failed to parse recipe from URL");
+    await jobLogger.fail("Failed to parse recipe from URL");
     throw new Error("Failed to parse recipe from URL");
   }
 
+  if (parseResult.usedAI && aiConfig?.model) {
+    await jobLogger.setAiModel(aiConfig.model);
+  }
+
+  await jobLogger.completeStep("parse_recipe", {
+    usedAI: parseResult.usedAI,
+    title: parseResult.recipe.title,
+  });
+
+  // Step 4: Save recipe to database
+  await jobLogger.startStep("save_recipe");
   const createdId = await createRecipeWithRefs(recipeId, userId, parseResult.recipe);
 
   if (!createdId) {
+    await jobLogger.failStep("save_recipe", "Failed to save imported recipe");
+    await jobLogger.fail("Failed to save imported recipe");
     throw new Error("Failed to save imported recipe");
   }
 
+  await jobLogger.completeStep("save_recipe", { createdRecipeId: createdId });
+
+  // Step 5: Post-processing (emit events, trigger follow-up jobs)
+  await jobLogger.startStep("post_processing");
   const dashboardDto = await dashboardRecipe(createdId);
 
   if (dashboardDto) {
@@ -134,8 +176,6 @@ async function processImportJob(job: Job<RecipeImportJobData>): Promise<void> {
       "Recipe imported successfully"
     );
 
-    // If AI was used, no processing will follow - show imported toast
-    // If AI was NOT used, auto-tagging/allergy detection will follow - no toast needed
     emitByPolicy(recipeEmitter, viewPolicy, ctx, "imported", {
       recipe: dashboardDto,
       pendingRecipeId: recipeId,
@@ -143,7 +183,6 @@ async function processImportJob(job: Job<RecipeImportJobData>): Promise<void> {
     });
 
     // Trigger auto-tagging only if AI was NOT used for extraction
-    // (AI extraction already includes auto-tagging instructions in the prompt)
     if (!parseResult.usedAI) {
       const queues = getQueues();
 
@@ -153,16 +192,12 @@ async function processImportJob(job: Job<RecipeImportJobData>): Promise<void> {
         householdKey,
       });
 
-      // Trigger allergy detection for structured imports
-      // (AI extraction already handles allergy detection inline)
       await addAllergyDetectionJob(queues.allergyDetection, {
         recipeId: createdId,
         userId,
         householdKey,
       });
 
-      // Trigger auto-categorization for structured imports without categories
-      // (AI extraction already includes categorization in the prompt)
       if (!parseResult.recipe.categories?.length) {
         await addAutoCategorizationJob(queues.autoCategorization, {
           recipeId: createdId,
@@ -172,6 +207,15 @@ async function processImportJob(job: Job<RecipeImportJobData>): Promise<void> {
       }
     }
   }
+
+  await jobLogger.completeStep("post_processing", {
+    triggeredFollowUp: !parseResult.usedAI,
+  });
+  await jobLogger.complete({
+    recipeId: createdId,
+    title: parseResult.recipe.title,
+    usedAI: parseResult.usedAI,
+  });
 }
 
 /**
@@ -200,6 +244,18 @@ async function handleJobFailed(
     },
     "Recipe import job failed"
   );
+
+  // Log failure to job_logs (find existing log by jobId)
+  if (isFinalFailure) {
+    const { findJobLogByJobId, markJobFailed: markFailed } = await import(
+      "@norish/db/repositories/job-logs"
+    );
+    const existingLog = await findJobLogByJobId(job.id!, QUEUE_NAMES.RECIPE_IMPORT);
+
+    if (existingLog) {
+      await markFailed(existingLog.id, error.message || "Unknown error");
+    }
+  }
 
   await deleteRecipeImagesDir(recipeId);
 

--- a/packages/queue/src/recipe-import/worker.ts
+++ b/packages/queue/src/recipe-import/worker.ts
@@ -63,6 +63,7 @@ async function processImportJob(job: Job<RecipeImportJobData>): Promise<void> {
     description: url,
     input: { url, forceAI: job.data.forceAI ?? false },
     steps: ["check_existing", "fetch_allergies", "parse_recipe", "save_recipe", "post_processing"],
+    attempt: job.attemptsMade + 1,
   });
 
   const policy = await getRecipePermissionPolicy();

--- a/packages/queue/src/recipe-import/worker.ts
+++ b/packages/queue/src/recipe-import/worker.ts
@@ -126,18 +126,28 @@ async function processImportJob(job: Job<RecipeImportJobData>): Promise<void> {
   // Step 3: Parse recipe from URL
   await jobLogger.startStep("parse_recipe");
   const userTokens = await getDecryptedTokensByUserId(userId);
-  const parseResult = await withTimeout(
-    () =>
-      parseRecipeFromUrl(
-        url,
-        recipeId,
-        allergyNames,
-        job.data.forceAI,
-        userTokens.length > 0 ? userTokens : undefined
-      ),
-    RECIPE_IMPORT_PROCESSING_TIMEOUT_MS,
-    "Recipe import parsing"
-  );
+  let parseResult: Awaited<ReturnType<typeof parseRecipeFromUrl>>;
+
+  try {
+    parseResult = await withTimeout(
+      () =>
+        parseRecipeFromUrl(
+          url,
+          recipeId,
+          allergyNames,
+          job.data.forceAI,
+          userTokens.length > 0 ? userTokens : undefined
+        ),
+      RECIPE_IMPORT_PROCESSING_TIMEOUT_MS,
+      "Recipe import parsing"
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Failed to parse recipe from URL";
+
+    await jobLogger.failStep("parse_recipe", msg);
+    await jobLogger.fail(msg);
+    throw err;
+  }
 
   log.debug({ parseResult }, "Recipe parse result");
   if (!parseResult.recipe) {

--- a/packages/queue/src/scheduled-tasks/producer.ts
+++ b/packages/queue/src/scheduled-tasks/producer.ts
@@ -57,5 +57,11 @@ export async function initializeScheduledJobs(queue: Queue<ScheduledTaskJobData>
     { repeat: { pattern: cronMidnight }, jobId: "video-temp-cleanup" }
   );
 
+  await queue.add(
+    "job-logs-cleanup",
+    { taskType: "job-logs-cleanup" },
+    { repeat: { pattern: cronMidnight }, jobId: "job-logs-cleanup" }
+  );
+
   log.info("Repeatable scheduled jobs initialized (daily at midnight)");
 }

--- a/packages/queue/src/scheduled-tasks/queue.ts
+++ b/packages/queue/src/scheduled-tasks/queue.ts
@@ -16,7 +16,8 @@ export type ScheduledTaskType =
   | "media-cleanup"
   | "calendar-cleanup"
   | "groceries-cleanup"
-  | "video-temp-cleanup";
+  | "video-temp-cleanup"
+  | "job-logs-cleanup";
 
 export interface ScheduledTaskJobData {
   taskType: ScheduledTaskType;

--- a/packages/queue/src/scheduled-tasks/worker.ts
+++ b/packages/queue/src/scheduled-tasks/worker.ts
@@ -1,6 +1,7 @@
 import type { Job } from "bullmq";
 import { Worker } from "bullmq";
 
+import { deleteOldJobLogs } from "@norish/db/repositories/job-logs";
 import { requireQueueApiHandler } from "@norish/queue/api-handlers";
 import { getBullClient } from "@norish/queue/redis/bullmq";
 import { cleanupOldCalendarData } from "@norish/queue/scheduler/old-calendar-cleanup";
@@ -17,7 +18,8 @@ type ScheduledTaskType =
   | "media-cleanup"
   | "calendar-cleanup"
   | "groceries-cleanup"
-  | "video-temp-cleanup";
+  | "video-temp-cleanup"
+  | "job-logs-cleanup";
 
 interface ScheduledTaskJobData {
   taskType: ScheduledTaskType;
@@ -86,6 +88,17 @@ async function processScheduledTask(job: Job<ScheduledTaskJobData>): Promise<voi
     case "video-temp-cleanup": {
       await cleanupOldTempFiles();
       log.info("Video temp cleanup completed");
+      break;
+    }
+
+    case "job-logs-cleanup": {
+      // Delete job logs older than 30 days
+      const cutoff = new Date();
+
+      cutoff.setDate(cutoff.getDate() - 30);
+      const deleted = await deleteOldJobLogs(cutoff);
+
+      log.info({ deleted }, "Job logs cleanup completed");
       break;
     }
 

--- a/packages/trpc/src/routers/admin/index.ts
+++ b/packages/trpc/src/routers/admin/index.ts
@@ -4,6 +4,7 @@ import { authProvidersProcedures } from "./auth-providers";
 import { adminConfigProcedures } from "./config";
 import { contentConfigProcedures } from "./content-config";
 import { generalProcedures } from "./general";
+import { jobsProcedures } from "./jobs";
 import { permissionsProcedures } from "./permissions";
 import { systemProcedures } from "./system";
 
@@ -28,4 +29,7 @@ export const adminRouter = router({
 
   // System (scheduler, restart, restore)
   ...systemProcedures._def.procedures,
+
+  // Jobs (viewable job queue)
+  jobs: jobsProcedures,
 });

--- a/packages/trpc/src/routers/admin/jobs.ts
+++ b/packages/trpc/src/routers/admin/jobs.ts
@@ -1,0 +1,90 @@
+import { z } from "zod";
+
+import {
+  deleteOldJobLogs,
+  getJobLog,
+  getJobStats,
+  listJobLogs,
+} from "@norish/db/repositories/job-logs";
+import { trpcLogger as log } from "@norish/shared-server/logger";
+
+import { adminProcedure } from "../../middleware";
+import { router } from "../../trpc";
+
+/**
+ * List jobs with pagination and optional filters.
+ */
+const listJobs = adminProcedure
+  .input(
+    z.object({
+      limit: z.number().min(1).max(100).default(20),
+      offset: z.number().min(0).default(0),
+      queueName: z.string().optional(),
+      status: z.enum(["queued", "active", "completed", "failed"]).optional(),
+      userId: z.string().optional(),
+      fromDate: z.string().datetime().optional(),
+      toDate: z.string().datetime().optional(),
+    })
+  )
+  .query(async ({ input }) => {
+    const result = await listJobLogs({
+      limit: input.limit,
+      offset: input.offset,
+      queueName: input.queueName,
+      status: input.status,
+      userId: input.userId,
+      fromDate: input.fromDate ? new Date(input.fromDate) : undefined,
+      toDate: input.toDate ? new Date(input.toDate) : undefined,
+    });
+
+    return result;
+  });
+
+/**
+ * Get detailed view of a single job.
+ */
+const getJob = adminProcedure
+  .input(z.object({ id: z.string() }))
+  .query(async ({ input }) => {
+    const job = await getJobLog(input.id);
+
+    return job;
+  });
+
+/**
+ * Get aggregate job stats (counts by status and queue).
+ */
+const stats = adminProcedure.query(async () => {
+  return getJobStats();
+});
+
+/**
+ * Manually purge old job logs.
+ */
+const purgeOldJobs = adminProcedure
+  .input(
+    z.object({
+      olderThanDays: z.number().min(1).max(365).default(30),
+    })
+  )
+  .mutation(async ({ input, ctx }) => {
+    const cutoff = new Date();
+
+    cutoff.setDate(cutoff.getDate() - input.olderThanDays);
+
+    log.info(
+      { userId: ctx.user.id, olderThanDays: input.olderThanDays },
+      "Purging old job logs"
+    );
+
+    const deleted = await deleteOldJobLogs(cutoff);
+
+    return { deleted };
+  });
+
+export const jobsProcedures = router({
+  listJobs,
+  getJob,
+  stats,
+  purgeOldJobs,
+});


### PR DESCRIPTION
## Summary

Implements #248 - Viewable job queue for inspecting current and past background processing jobs.

## What's included

### Backend - Persistent Job Logging
- **New `job_logs` table** (migration 0035) with status, steps (JSONB pipeline), inputs, outputs, errors, timing, and AI model tracking
- **`JobLogger` utility class** (`packages/queue/src/job-logger.ts`) - workers use this to record each processing step with start/complete/fail/skip semantics. Gracefully handles logging failures (never breaks job processing).
- **Instrumented workers**: recipe-import, image-import, and paste-import workers now log step-by-step pipeline data
- **Automatic cleanup**: daily scheduled task deletes job logs older than 30 days

### Backend - API
- **New tRPC admin sub-router** (`admin.jobs`) with:
  - `listJobs` - paginated list with queue/status/user/date filters
  - `getJob` - detailed single job with all pipeline steps
  - `stats` - aggregate counts by status and queue
  - `purgeOldJobs` - manual cleanup mutation

### Frontend - Admin UI
- **Jobs Card** in admin settings with:
  - Filter by queue and status
  - Job list with progress circles (SVG pipeline visualization)
  - Pagination
  - Live polling (10s for list, 3s for active job detail)
- **Job Detail Modal** with:
  - Metadata grid (queue, job ID, AI model, timing, duration)
  - Pipeline steps timeline with status icons
  - Error display
  - Input/output JSON viewer
- **i18n**: Full English translations for all labels

## Architecture decisions

1. **PostgreSQL over BullMQ for history** - BullMQ deletes completed/failed jobs immediately (`removeOnComplete: true`). Persistent storage enables proper filtering, pagination, and long-term visibility.
2. **Non-blocking logging** - JobLogger catches all errors internally; a logging failure never breaks actual job processing.
3. **Admin-only scope** - Uses existing `adminProcedure` middleware. Only server admins can view job history.
4. **Incremental approach** - Core import workers instrumented first; enhancement workers (nutrition, tagging, etc.) can be added in follow-ups.

## Future enhancements (not in this PR)
- Navbar dropdown with active job count
- Real-time push via tRPC subscriptions
- Instrument remaining workers (nutrition, auto-tagging, allergy detection)
- Configurable retention period in admin settings

Closes #248
