### PR TITLE
fix(caldav): unwrap RealtimeEventEnvelope in CalDAV sync listener

### DIFF
--- a/packages/api/__tests__/server/caldav/event-listener.test.ts
+++ b/packages/api/__tests__/server/caldav/event-listener.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+
+import { unwrapRealtimeEventEnvelope } from "@norish/api/caldav/event-listener";
+
+describe("unwrapRealtimeEventEnvelope", () => {
+  it("unwraps a RealtimeEventEnvelope to its payload", () => {
+    const payload = {
+      item: {
+        id: "00000000-0000-0000-0000-000000000001",
+        userId: "user_1",
+        itemType: "recipe",
+        date: "2026-06-09",
+        slot: "Dinner",
+        recipeName: "Test Recipe",
+      },
+    };
+    const envelope = {
+      meta: {
+        version: 1,
+        eventId: "11111111-1111-1111-1111-111111111111",
+        eventName: "itemCreated",
+        namespace: "calendar",
+        scope: "household",
+        channel: "norish:calendar:household:hh_1:itemCreated",
+        occurredAt: "2026-06-05T00:00:00.000Z",
+      },
+      payload,
+    };
+
+    expect(unwrapRealtimeEventEnvelope(envelope)).toBe(payload);
+  });
+
+  it("passes through legacy un-enveloped payloads unchanged", () => {
+    // Pre-envelope-refactor publishes wrote the payload directly.
+    const legacy = {
+      item: {
+        id: "00000000-0000-0000-0000-000000000002",
+        userId: "user_2",
+        itemType: "recipe",
+        date: "2026-06-09",
+        slot: "Dinner",
+        recipeName: "Legacy Shape",
+      },
+    };
+
+    expect(unwrapRealtimeEventEnvelope(legacy)).toBe(legacy);
+  });
+
+  it("passes through itemDeleted envelopes too", () => {
+    const payload = { itemId: "00000000-0000-0000-0000-000000000003" };
+    const envelope = {
+      meta: {
+        version: 1,
+        eventId: "22222222-2222-2222-2222-222222222222",
+        eventName: "itemDeleted",
+        namespace: "calendar",
+        scope: "household",
+        channel: "norish:calendar:household:hh_1:itemDeleted",
+        occurredAt: "2026-06-05T00:00:00.000Z",
+      },
+      payload,
+    };
+
+    expect(unwrapRealtimeEventEnvelope(envelope)).toBe(payload);
+  });
+
+  it("returns null/undefined inputs as-is", () => {
+    expect(unwrapRealtimeEventEnvelope(null)).toBeNull();
+    expect(unwrapRealtimeEventEnvelope(undefined)).toBeUndefined();
+  });
+
+  it("does not mistake an object with only `meta` for an envelope", () => {
+    const partial = { meta: { foo: "bar" } };
+    expect(unwrapRealtimeEventEnvelope(partial)).toBe(partial);
+  });
+
+  it("does not mistake an object with only `payload` for an envelope", () => {
+    const partial = { payload: { x: 1 } };
+    expect(unwrapRealtimeEventEnvelope(partial)).toBe(partial);
+  });
+});

--- a/packages/api/src/caldav/event-listener.ts
+++ b/packages/api/src/caldav/event-listener.ts
@@ -1,9 +1,10 @@
 import type Redis from "ioredis";
+import superjson from "superjson";
+
 import type { Slot } from "@norish/shared/contracts";
+import type { RealtimeEventEnvelope } from "@norish/shared/contracts/realtime-envelope";
 import type { CalendarSubscriptionEvents } from "@norish/trpc/routers/calendar/types";
 import type { RecipeSubscriptionEvents } from "@norish/trpc/routers/recipes/types";
-
-import superjson from "superjson";
 import { getCaldavConfigDecrypted } from "@norish/db/repositories/caldav-config";
 import { getCaldavSyncStatusByItemId } from "@norish/db/repositories/caldav-sync-status";
 import { addCaldavSyncJob } from "@norish/queue/caldav-sync/producer";
@@ -11,6 +12,29 @@ import { createSubscriberClient } from "@norish/queue/redis/client";
 import { getQueues } from "@norish/queue/registry";
 import { createLogger } from "@norish/shared-server/logger";
 import { recipeEmitter } from "@norish/trpc/routers/recipes/emitter";
+
+/**
+ * Unwrap a RealtimeEventEnvelope to its inner payload.
+ *
+ * The Redis emitter (packages/queue/src/redis/pubsub.ts) wraps published
+ * messages in `{ meta, payload }` for any channel matching the standard
+ * `norish:<namespace>:<scope>:...` shape — which includes every
+ * `norish:calendar:household:*:*` event this listener consumes.
+ *
+ * The pmessage handler below uses `subscriber.psubscribe()` directly
+ * (rather than the envelope-aware `createSubscription()` helper, which
+ * does not support pattern-subscribe), so we must unwrap here.
+ *
+ * Backward-compatible: legacy non-enveloped messages pass through.
+ * Exported for unit testing.
+ */
+export function unwrapRealtimeEventEnvelope(data: unknown): unknown {
+  if (data !== null && typeof data === "object" && "meta" in data && "payload" in data) {
+    return (data as RealtimeEventEnvelope).payload;
+  }
+
+  return data;
+}
 
 const log = createLogger("caldav-sync");
 
@@ -152,7 +176,7 @@ async function startCalendarSubscriptions(signal: AbortSignal): Promise<void> {
       let data: unknown;
 
       try {
-        data = superjson.parse(message);
+        data = unwrapRealtimeEventEnvelope(superjson.parse(message));
       } catch (err) {
         log.error({ err, channel }, "Failed to parse calendar event message");
 


### PR DESCRIPTION
## Summary
The CalDAV sync listener crashes on every UI-triggered meal plan since the `2026-03-16-traceable-event-envelopes` refactor. The Redis emitter now wraps published messages in a `RealtimeEventEnvelope`, but the CalDAV listener (which uses raw `subscriber.psubscribe()` rather than the envelope-aware `createSubscription` helper) was not updated to unwrap.

## Repro
1. v0.18.3-beta with CalDAV configured + `enabled: true` on `user_caldav_config`
2. Schedule a meal in the UI
3. Listener log shows:
   ```
   TypeError: Cannot read properties of undefined (reading 'itemType')
       at handleCalendarEvent (event-listener.ts:...)
   eventName: itemCreated
   ```
4. No sync job is enqueued, no CalDAV PUT happens, `caldav_sync_status` stays empty.

## Root cause
`packages/queue/src/redis/pubsub.ts` `publish()` checks `parseChannelMetadata(channel)` and wraps in `{ meta, payload }` for any channel matching `norish:<namespace>:<scope>:...`. Calendar channels match (`namespace=calendar`, `scope=household`), so the listener gets the envelope instead of the raw payload.

The `createSubscription` helper in pubsub.ts can't be reused here because it doesn't support pattern-subscribe (the listener needs `household:*:*` wildcard for multi-household psubscribe).

## Fix
Extract `unwrapRealtimeEventEnvelope` helper, call it after `superjson.parse`. The helper detects an envelope (`meta` + `payload` keys both present) and returns `.payload`, otherwise returns the input unchanged. Backward-compatible with legacy un-enveloped messages.

## Tests
- 6 new unit tests in `packages/api/__tests__/server/caldav/event-listener.test.ts`:
  - Unwraps a `RealtimeEventEnvelope` to its payload
  - Passes through legacy un-enveloped payloads unchanged
  - Handles `itemDeleted` envelopes
  - Handles `null` / `undefined` inputs
  - Does NOT mistake objects with only `meta` (and not `payload`) for an envelope
  - Does NOT mistake objects with only `payload` (and not `meta`) for an envelope
- All 336 tests in `@norish/api` pass.

## Verification
End-to-end on a self-hosted v0.18.3-beta install: with this patch, scheduling a meal now produces a `201 Created` PUT to Radicale and writes a `sync_status: synced` row to `caldav_sync_status`.

## Out of scope / followups
- The recipe-emitter consumers using `createSubscription` may have the same envelope issue — they pull `parsed: TEvents[K]` straight out of `superjson.parse` without unwrap. Did not investigate; flagging for maintainer awareness.
- Channel metadata is available via `parseChannelMetadata` from `@norish/queue/redis/channel-metadata` if a typed envelope-aware pattern-subscribe helper would be useful as a follow-up refactor.