### PR TITLE
fix(ai): remove `@context`/`@type` keys from recipeExtractionSchema (Anthropic compatibility)

### DIFF
--- a/packages/api/__tests__/ai/features/recipe-extraction/normalizer.test.ts
+++ b/packages/api/__tests__/ai/features/recipe-extraction/normalizer.test.ts
@@ -204,8 +204,6 @@ describe("getExtractionLogContext", () => {
 
   it("handles missing arrays in output gracefully", () => {
     const output = {
-      "@context": "https://schema.org",
-      "@type": "Recipe",
       name: "Test Recipe",
       description: null,
       recipeYield: null,
@@ -238,8 +236,6 @@ describe("getExtractionLogContext", () => {
 
 function createValidOutput(): RecipeExtractionOutput {
   return {
-    "@context": "https://schema.org",
-    "@type": "Recipe",
     name: "Chocolate Cake",
     description: "A delicious chocolate cake",
     recipeIngredient: {
@@ -275,8 +271,6 @@ function createPartialOutput(overrides: Partial<RecipeExtractionOutput>): Recipe
 describe("normalizeExtractionOutput - HTML Entity Decoding", () => {
   it("keeps metric and US systems separated even when base normalizer infers US", async () => {
     const output: RecipeExtractionOutput = {
-      "@context": "https://schema.org",
-      "@type": "Recipe",
       name: "Mapo Tofu Udon",
       description: "Test",
       notes: null,
@@ -346,8 +340,6 @@ describe("normalizeExtractionOutput - HTML Entity Decoding", () => {
 
   it("normalizes categories with matcher", async () => {
     const output: RecipeExtractionOutput = {
-      "@context": "https://schema.org",
-      "@type": "Recipe",
       name: "Test Recipe",
       notes: null,
       description: "Test",
@@ -398,8 +390,6 @@ describe("normalizeExtractionOutput - HTML Entity Decoding", () => {
 
   it("decodes HTML entities in US ingredients and keeps comments", async () => {
     const output: RecipeExtractionOutput = {
-      "@context": "https://schema.org",
-      "@type": "Recipe",
       name: "Test Recipe",
       description: "Test",
       notes: null,
@@ -468,8 +458,6 @@ describe("normalizeExtractionOutput - HTML Entity Decoding", () => {
 
   it("decodes HTML entities in US steps and keeps full text", async () => {
     const output: RecipeExtractionOutput = {
-      "@context": "https://schema.org",
-      "@type": "Recipe",
       name: "Test Recipe",
       description: "Test",
       recipeIngredient: {
@@ -532,8 +520,6 @@ describe("normalizeExtractionOutput - HTML Entity Decoding", () => {
 
   it("decodes multiple entity types in US content", async () => {
     const output: RecipeExtractionOutput = {
-      "@context": "https://schema.org",
-      "@type": "Recipe",
       name: "Test Recipe",
       description: "Test",
       recipeIngredient: {
@@ -596,8 +582,6 @@ describe("normalizeExtractionOutput - HTML Entity Decoding", () => {
 
   it("handles US ingredients without entities", async () => {
     const output: RecipeExtractionOutput = {
-      "@context": "https://schema.org",
-      "@type": "Recipe",
       name: "Test Recipe",
       description: "Test",
       recipeIngredient: {
@@ -652,8 +636,6 @@ describe("normalizeExtractionOutput - HTML Entity Decoding", () => {
 
   it("maps and decodes notes from AI output", async () => {
     const output: RecipeExtractionOutput = {
-      "@context": "https://schema.org",
-      "@type": "Recipe",
       name: "Test Recipe",
       description: "Test",
       notes: "Let it rest for 10 minutes &#8211; don&#39;t skip this step.",

--- a/packages/api/__tests__/ai/features/recipe-extraction/schema.test.ts
+++ b/packages/api/__tests__/ai/features/recipe-extraction/schema.test.ts
@@ -1,0 +1,37 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { recipeExtractionSchema } from "@norish/api/ai/schemas/recipe.schema";
+
+// Anthropic's Messages API validates tool input_schema property keys against
+// this pattern and rejects the whole request on any mismatch, which breaks
+// every AI extraction call (image/URL/video import) on the Anthropic provider.
+const ANTHROPIC_PROPERTY_KEY = /^[a-zA-Z0-9_.-]{1,64}$/;
+
+function collectPropertyKeys(node: unknown, keys: string[] = []): string[] {
+  if (node === null || typeof node !== "object") return keys;
+  if (Array.isArray(node)) {
+    for (const item of node) collectPropertyKeys(item, keys);
+    return keys;
+  }
+  const record = node as Record<string, unknown>;
+  if (record.properties && typeof record.properties === "object") {
+    keys.push(...Object.keys(record.properties));
+  }
+  for (const value of Object.values(record)) collectPropertyKeys(value, keys);
+  return keys;
+}
+
+describe("recipeExtractionSchema", () => {
+  it("only uses property keys accepted by Anthropic tool input schemas", () => {
+    const jsonSchema = z.toJSONSchema(recipeExtractionSchema);
+    const invalid = collectPropertyKeys(jsonSchema).filter(
+      (key) => !ANTHROPIC_PROPERTY_KEY.test(key)
+    );
+
+    expect(invalid).toEqual([]);
+  });
+});

--- a/packages/api/src/ai/schemas/recipe.schema.ts
+++ b/packages/api/src/ai/schemas/recipe.schema.ts
@@ -8,8 +8,8 @@ import { nutritionEstimationSchema } from "./nutrition.schema";
  */
 export const recipeExtractionSchema = z
   .object({
-    "@context": z.literal("https://schema.org").describe("Schema.org context"),
-    "@type": z.literal("Recipe").describe("Schema.org type"),
+    // No "@context"/"@type" schema.org keys here: Anthropic rejects tool
+    // input_schema property keys that don't match ^[a-zA-Z0-9_.-]{1,64}$
     name: z.string().describe("Recipe name/title"),
     description: z.string().nullable().describe("Brief recipe description"),
     notes: z


### PR DESCRIPTION
## Problem

With the Anthropic AI provider selected, every AI recipe extraction fails: image import, the AI fallback for URL/paste import, and video import. Anthropic rejects the request before generation even starts:

```
invalid_request_error
tools.0.custom.input_schema.properties: Property keys should match pattern '^[a-zA-Z0-9_.-]{1,64}$'
```

## Root cause

`packages/api/src/ai/schemas/recipe.schema.ts` contained schema.org-style keys:

```ts
"@context": z.literal("https://schema.org").describe("Schema.org context"),
"@type": z.literal("Recipe").describe("Schema.org type"),
```

The AI SDK sends structured-output schemas to Anthropic as a tool `input_schema`, and Anthropic validates property keys against `^[a-zA-Z0-9_.-]{1,64}$`. `@` is not permitted, so the whole request is rejected. OpenAI-compatible providers accept `@`-prefixed keys, which is why this never surfaced there.

Other AI features (nutrition estimation, allergy detection, auto-tagging, unit conversion) are fine; their schemas contain no such keys.

## Fix

Remove the two keys from the AI-facing schema. I removed them instead of renaming because both were `z.literal()` constants: the model was only forced to echo two fixed strings, which tells us nothing about the recipe and wastes a few output tokens per call.

Nothing downstream reads them either. `normalizeExtractionOutput` hands the output to `normalizeRecipeFromJson`, which never touches `@type` or `@context` (see `packages/api/src/parser/normalize.ts`). The `@type` readers in the classic parser (`parser/jsonld.ts`, `parser/parsers/*`) work on scraped JSON-LD, not on AI extraction output, and are untouched.

Test fixtures in `packages/api/__tests__/ai/features/recipe-extraction/normalizer.test.ts` were updated to match (9 fixture objects).

There is also a new regression test (`__tests__/ai/features/recipe-extraction/schema.test.ts`). It converts `recipeExtractionSchema` to JSON Schema with `z.toJSONSchema`, the same conversion the AI SDK performs, and asserts that every property key matches Anthropic's pattern. Before the schema change it failed with exactly `["@context", "@type"]`.

## Testing

- Reproduced on `norishapp/norish:latest` with provider `anthropic` (`claude-haiku-4-5`): 100% of extraction calls failed with the error above; other AI features worked.
- After the schema change, extraction requests pass Anthropic's validation.
- Full `@norish/api` suite: 26 test files, 323 tests, all passing.
- The `@type`-dependent parser tests (`videos.test.ts`, `normalize.test.ts`, `python-adapter.test.ts`) still pass untouched; they exercise the scraped-JSON-LD path.
