### PR TITLE
chore(video): bump pinned yt-dlp to 2026.07.04

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -159,7 +159,7 @@ RUN find /app/packages -type d -name '__tests__' -exec rm -rf {} + 2>/dev/null; 
 ##############################
 FROM base AS ytdlp
 
-ARG YT_DLP_VERSION=2026.03.17
+ARG YT_DLP_VERSION=2026.07.04
 ARG TARGETARCH
 
 RUN apk add --no-cache curl

--- a/packages/api/src/startup/seed-config.ts
+++ b/packages/api/src/startup/seed-config.ts
@@ -668,7 +668,7 @@ export function getDefaultConfigValue(key: ServerConfigKey): unknown {
         enabled: false,
         maxLengthSeconds: 120,
         maxVideoFileSize: SERVER_CONFIG.MAX_VIDEO_FILE_SIZE,
-        ytDlpVersion: "2025.11.12",
+        ytDlpVersion: "2026.07.04",
         transcriptionProvider: "disabled",
         transcriptionModel: "whisper-1",
       };

--- a/packages/config/src/env-config-server.ts
+++ b/packages/config/src/env-config-server.ts
@@ -174,7 +174,7 @@ const ServerConfigSchema = z.object({
     .default(false),
   VIDEO_MAX_LENGTH_SECONDS: z.coerce.number().default(120),
   YT_DLP_PROXY: z.string().optional(),
-  YT_DLP_VERSION: z.string().default("2025.11.12"),
+  YT_DLP_VERSION: z.string().default("2026.07.04"),
   YT_DLP_BIN_DIR: z.string().default(defaultYtDlpBinDir),
 
   // Transcription Configuration (separate from AI_PROVIDER)

--- a/packages/shared-server/src/config/defaults.ts
+++ b/packages/shared-server/src/config/defaults.ts
@@ -37,7 +37,7 @@ export function getDefaultConfigValue(key: ServerConfigKey): unknown {
         enabled: false,
         maxLengthSeconds: 120,
         maxVideoFileSize: SERVER_CONFIG.MAX_VIDEO_FILE_SIZE,
-        ytDlpVersion: "2025.11.12",
+        ytDlpVersion: "2026.07.04",
         ytDlpProxy: undefined,
         transcriptionProvider: "disabled",
         transcriptionModel: "whisper-1",


### PR DESCRIPTION
Instagram imports are currently broken, even for plain images that don't need a login. The pinned yt-dlp is old enough that it prints its "version is older than 90 days" warning and then the Instagram extractor fails. Nothing is wrong on the Norish side, the extractor has just rotted.

I hit this on my own instance and confirmed the fix there: swapped the binary for 2026.07.04 (the `yt-dlp_musllinux` asset, since the image is Alpine; the glibc `yt-dlp_linux` build won't run in it) and Reel imports worked again immediately. The Dockerfile already picks the right musl asset per arch, so this PR only bumps version literals.

Four places pin a version:

- `docker/Dockerfile`: build ARG `YT_DLP_VERSION`, was 2026.03.17
- `packages/config/src/env-config-server.ts`: the `YT_DLP_VERSION` env default used as the runtime download fallback, was 2025.11.12
- `packages/api/src/startup/seed-config.ts` and `packages/shared-server/src/config/defaults.ts`: the two restore-to-defaults `VIDEO_CONFIG.ytDlpVersion` literals, also 2025.11.12

All four now say 2026.07.04, the latest release at the time of writing.

Checks: typecheck passes for the touched packages (`@norish/config`, `@norish/api`, `@norish/shared-server`; `@norish/db` fails to typecheck on current `main` too, so that one is pre-existing). All 322 `@norish/api` tests pass, including the import-flow test that reads `YT_DLP_VERSION`.

One thought for later, deliberately not part of this diff: this pin will rot again in roughly three months, because that's how fast yt-dlp extractors churn. Resolving the latest release at image build time in CI would stop that. I can open a follow-up if you want one.
