### PR TITLE
fix(ai): reject all-zero nutrition estimates instead of persisting them

### DIFF
--- a/packages/api/__tests__/ai/nutrition-estimator.test.ts
+++ b/packages/api/__tests__/ai/nutrition-estimator.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Nutrition Estimator Tests
+ *
+ * Tests for AI-based nutrition estimation, including rejection of
+ * physically impossible all-zero estimates.
+ *
+ * @vitest-environment node
+ */
+import { generateText } from "ai";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { estimateNutritionFromIngredients } from "@norish/api/ai/nutrition-estimator";
+import { isAIEnabled } from "@norish/shared-server/config/server-config-loader";
+
+// Mock dependencies - vi.mock is hoisted by Vitest
+vi.mock("ai", () => ({
+  generateText: vi.fn(),
+  Output: {
+    object: vi.fn(({ schema }) => schema),
+  },
+}));
+
+vi.mock("@norish/shared-server/config/server-config-loader", () => ({
+  isAIEnabled: vi.fn(),
+}));
+
+vi.mock("@norish/shared-server/ai/providers", () => ({
+  getModels: vi.fn().mockResolvedValue({
+    model: {},
+    providerName: "anthropic",
+  }),
+  getGenerationSettings: vi.fn().mockResolvedValue({
+    temperature: 0.2,
+    maxTokens: 3000,
+  }),
+}));
+
+vi.mock("@norish/shared-server/ai/prompts/loader", () => ({
+  loadPrompt: vi.fn().mockResolvedValue("Mock nutrition estimation prompt template"),
+  fillPrompt: vi.fn((template, _vars) => template),
+}));
+
+vi.mock("@norish/shared-server/logger", () => ({
+  aiLogger: {
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+type GenerateTextResult = ReturnType<typeof generateText> extends Promise<infer R> ? R : never;
+
+function mockAIOutput(output: unknown): void {
+  vi.mocked(generateText).mockResolvedValue({
+    output,
+    usage: { inputTokens: 100, outputTokens: 20, totalTokens: 120 },
+  } as GenerateTextResult);
+}
+
+describe("estimateNutritionFromIngredients", () => {
+  const measuredIngredients = [
+    { ingredientName: "Spaghettini", amount: 600, unit: "gram" },
+    { ingredientName: "Olivenöl", amount: 80, unit: "milliliter" },
+    { ingredientName: "Knoblauchzehe(n)", amount: 5, unit: null },
+    { ingredientName: "Salz", amount: null, unit: null },
+  ];
+
+  const unmeasuredIngredients = [
+    { ingredientName: "Salz", amount: null, unit: null },
+    { ingredientName: "Parmesan", amount: null, unit: null },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(isAIEnabled).mockResolvedValue(true);
+  });
+
+  it("returns error when AI is disabled", async () => {
+    vi.mocked(isAIEnabled).mockResolvedValue(false);
+
+    const result = await estimateNutritionFromIngredients("Pasta", 4, measuredIngredients);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.code).toBe("AI_DISABLED");
+    }
+  });
+
+  it("returns error when no ingredients are provided", async () => {
+    const result = await estimateNutritionFromIngredients("Pasta", 4, []);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.code).toBe("INVALID_INPUT");
+    }
+  });
+
+  it("returns the estimate for a normal response", async () => {
+    mockAIOutput({ calories: 700, fat: 20, carbs: 110, protein: 21 });
+
+    const result = await estimateNutritionFromIngredients("Pasta", 4, measuredIngredients);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual({ calories: 700, fat: 20, carbs: 110, protein: 21 });
+      expect(result.usage?.totalTokens).toBe(120);
+    }
+  });
+
+  it("rejects an all-zero estimate when ingredients have parsed amounts", async () => {
+    mockAIOutput({ calories: 0, fat: 0, carbs: 0, protein: 0 });
+
+    const result = await estimateNutritionFromIngredients("Pasta", 4, measuredIngredients);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.code).toBe("INVALID_OUTPUT");
+    }
+  });
+
+  it("accepts an all-zero estimate when no ingredient has a parsed amount", async () => {
+    mockAIOutput({ calories: 0, fat: 0, carbs: 0, protein: 0 });
+
+    const result = await estimateNutritionFromIngredients(
+      "Gewürzmischung",
+      4,
+      unmeasuredIngredients
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual({ calories: 0, fat: 0, carbs: 0, protein: 0 });
+    }
+  });
+
+  it("accepts a zero-calorie estimate when other values are non-zero", async () => {
+    mockAIOutput({ calories: 0, fat: 0, carbs: 1, protein: 0 });
+
+    const result = await estimateNutritionFromIngredients("Kräutertee", 4, measuredIngredients);
+
+    expect(result.success).toBe(true);
+  });
+
+  it("returns error when AI returns empty output", async () => {
+    mockAIOutput(null);
+
+    const result = await estimateNutritionFromIngredients("Pasta", 4, measuredIngredients);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.code).toBe("EMPTY_RESPONSE");
+    }
+  });
+
+  it("returns error when AI response is missing fields", async () => {
+    mockAIOutput({ calories: 700, fat: 20 });
+
+    const result = await estimateNutritionFromIngredients("Pasta", 4, measuredIngredients);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.code).toBe("VALIDATION_ERROR");
+    }
+  });
+});

--- a/packages/api/src/ai/nutrition-estimator.ts
+++ b/packages/api/src/ai/nutrition-estimator.ts
@@ -115,6 +115,28 @@ export async function estimateNutritionFromIngredients(
       return aiError("AI response missing required fields", "VALIDATION_ERROR");
     }
 
+    // A recipe with at least one measured ingredient cannot be all-zero;
+    // models intermittently emit zeros, which must not be persisted.
+    const hasMeasuredIngredient = ingredients.some((i) => i.amount != null);
+    const isAllZero =
+      output.calories === 0 && output.fat === 0 && output.carbs === 0 && output.protein === 0;
+
+    if (hasMeasuredIngredient && isAllZero) {
+      aiLogger.warn(
+        {
+          recipeName,
+          ingredientCount: ingredients.length,
+          calories: output.calories,
+          fat: output.fat,
+          carbs: output.carbs,
+          protein: output.protein,
+        },
+        "Rejecting all-zero nutrition estimate for recipe with measured ingredients"
+      );
+
+      return aiError("Nutrition estimation returned all-zero values", "INVALID_OUTPUT");
+    }
+
     aiLogger.info(
       {
         recipeName,

--- a/packages/queue/__tests__/nutrition-estimation/worker.test.ts
+++ b/packages/queue/__tests__/nutrition-estimation/worker.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getRecipeFull = vi.fn();
+const updateRecipeWithRefs = vi.fn();
+const emitByPolicy = vi.fn();
+const estimateNutritionFromIngredients = vi.fn();
+
+vi.mock("@norish/db", () => ({
+  getRecipeFull,
+  updateRecipeWithRefs,
+}));
+
+vi.mock("@norish/shared-server/config/server-config-loader", () => ({
+  getRecipePermissionPolicy: vi.fn().mockResolvedValue({ view: "everyone" }),
+}));
+
+vi.mock("@norish/queue/api-handlers", () => ({
+  requireQueueApiHandler: vi.fn(() => estimateNutritionFromIngredients),
+}));
+
+vi.mock("@norish/shared-server/realtime/policy", () => ({
+  emitByPolicy,
+}));
+
+vi.mock("@norish/shared-server/realtime/recipes", () => ({
+  recipeEmitter: {},
+}));
+
+vi.mock("@norish/shared-server/logger", () => ({
+  createLogger: () => ({ info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+const recipe = {
+  id: "recipe-123",
+  name: "Spaghettini aglio e olio",
+  servings: 4,
+  recipeIngredients: [
+    { ingredientName: "Spaghettini", amount: 600, unit: "gram" },
+    { ingredientName: "Olivenöl", amount: 80, unit: "milliliter" },
+    { ingredientName: "Salz", amount: null, unit: null },
+  ],
+};
+
+const job = {
+  id: "job-1",
+  attemptsMade: 0,
+  opts: {},
+  data: {
+    recipeId: "recipe-123",
+    userId: "user-1",
+    householdKey: "household-1",
+  },
+} as any;
+
+describe("processNutritionJob", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getRecipeFull.mockResolvedValue(recipe);
+  });
+
+  it("saves the estimate and emits an update on success", async () => {
+    const { processNutritionJob } = await import("../../src/nutrition-estimation/worker");
+
+    estimateNutritionFromIngredients.mockResolvedValue({
+      success: true,
+      data: { calories: 700, fat: 20, carbs: 110, protein: 21 },
+    });
+
+    await processNutritionJob(job);
+
+    expect(updateRecipeWithRefs).toHaveBeenCalledWith("recipe-123", "user-1", {
+      calories: 700,
+      fat: "20",
+      carbs: "110",
+      protein: "21",
+    });
+    expect(emitByPolicy).toHaveBeenCalledWith(
+      expect.anything(),
+      "everyone",
+      expect.anything(),
+      "updated",
+      expect.anything()
+    );
+  });
+
+  it("throws on estimation failure so BullMQ retries, leaving the recipe unchanged", async () => {
+    const { processNutritionJob } = await import("../../src/nutrition-estimation/worker");
+
+    estimateNutritionFromIngredients.mockResolvedValue({
+      success: false,
+      error: "Nutrition estimation returned all-zero values",
+      code: "INVALID_OUTPUT",
+    });
+
+    await expect(processNutritionJob(job)).rejects.toThrow(
+      "Nutrition estimation returned all-zero values"
+    );
+
+    expect(updateRecipeWithRefs).not.toHaveBeenCalled();
+    expect(emitByPolicy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/queue/src/nutrition-estimation/worker.ts
+++ b/packages/queue/src/nutrition-estimation/worker.ts
@@ -22,7 +22,7 @@ import { createLazyWorker, stopLazyWorker } from "../lazy-worker-manager";
 
 const log = createLogger("worker:nutrition-estimation");
 
-async function processNutritionJob(job: Job<NutritionEstimationJobData>): Promise<void> {
+export async function processNutritionJob(job: Job<NutritionEstimationJobData>): Promise<void> {
   const estimateNutritionFromIngredients = requireQueueApiHandler(
     "estimateNutritionFromIngredients"
   );

--- a/packages/shared-server/src/ai/types/result.ts
+++ b/packages/shared-server/src/ai/types/result.ts
@@ -23,6 +23,7 @@ export type AIErrorCode =
   | "NETWORK_ERROR"
   | "TIMEOUT"
   | "INVALID_INPUT"
+  | "INVALID_OUTPUT"
   | "UNKNOWN";
 
 /**
@@ -107,6 +108,8 @@ export function getErrorMessage(code: AIErrorCode, originalMessage?: string): st
       return "AI returned an empty response. Try again or check your prompt.";
     case "INVALID_INPUT":
       return originalMessage || "Invalid input provided.";
+    case "INVALID_OUTPUT":
+      return originalMessage || "AI returned an implausible response.";
     case "PROVIDER_ERROR":
       return originalMessage || "AI provider returned an error.";
     default:


### PR DESCRIPTION
Nutrition estimation occasionally returns calories=0, fat=0, carbs=0, protein=0 for a recipe whose ingredient amounts parsed fine. The result is saved as-is, so a pasta dish can show zero calories with no error, no retry, and no warning. Re-running the estimation usually produces correct values.

Observed on a live instance with Anthropic (claude-sonnet-4-6), and earlier on other models. Repro recipe: Chefkoch "Spaghettini aglio e olio", 4 servings, 9 ingredients with parsed amounts (600 g Spaghettini, 80 ml olive oil, 5 garlic cloves, ...). Roughly 700 kcal / 20 g fat per serving would be correct; the model intermittently returned zeros anyway. Lowering the temperature seems to make it rarer, but there is no reason to ever save an all-zero estimate for a recipe with measured ingredients.

What changed:

- `estimateNutritionFromIngredients` rejects the output when at least one ingredient has a parsed amount and all four values are zero. It returns the new `INVALID_OUTPUT` error code and logs the rejection at warn level with the recipe name, ingredient count, and raw values, so the frequency is visible in production logs.
- No worker changes were needed for the retry behavior: the queue worker already throws on error results, so BullMQ retries the job (3 attempts, exponential backoff), and on final failure the existing failed event clears the UI loading state. Zeros are never persisted and existing nutrition values are never overwritten.
- `processNutritionJob` is now exported so the worker can be unit-tested, same as the image-import worker.

The guard sits in the estimator, so every caller gets it. The AI recipe-extraction path does not share it: extraction takes nutrition from its own schema (`recipeExtractionSchema`) and never calls the estimator.

Tests: new estimator suite (8 tests, including the all-zero rejection, the no-parsed-amounts case where zeros are allowed, and the existing error paths) and a new worker suite (success persists and emits, failure throws without touching the recipe).

Verification: typecheck passes for shared-server, api, and queue. Tests: shared-server 171, api 330, queue 78 passed. The only failing queue suite is the pre-existing Docker-only `paste-import/worker.integration.test.ts`, which also fails on main without this change. ESLint reports no errors for the touched files and prettier is clean.