### PR TITLE
Fix AI temperature slider controls

### DIFF
--- a/apps/web/app/(app)/settings/admin/components/ai-config-form.tsx
+++ b/apps/web/app/(app)/settings/admin/components/ai-config-form.tsx
@@ -438,7 +438,12 @@ export default function AIConfigForm({ onDirtyChange }: AIConfigFormProps) {
           step={0.1}
           value={temperature}
           onChange={(v) => setTemperature(v as number)}
-        />
+        >
+          <Slider.Track>
+            <Slider.Fill />
+            <Slider.Thumb />
+          </Slider.Track>
+        </Slider>
         <span className="text-muted text-xs">{t("temperatureHint")}</span>
       </div>
 


### PR DESCRIPTION
The AI temperature slider in the settings rendered as an empty track that could not be interacted with, so the temperature setting was stuck at its stored value.

The component rendered a self-closing HeroUI v3 `Slider`. HeroUI v3 sliders are compound components: without `Slider.Track`, `Slider.Fill`, and `Slider.Thumb` children, nothing is drawn and there is nothing to drag. This adds the missing children so the slider displays its value and accepts input again.

Verification: web typecheck (`pnpm --filter @norish/web exec tsc --noEmit`), ESLint and prettier on the changed component, and the web test suite (67 files, 404 tests passed).