### PR TITLE
Fix deterministic BullMQ job reruns

### DIFF
--- a/packages/queue/__tests__/queue/config.test.ts
+++ b/packages/queue/__tests__/queue/config.test.ts
@@ -2,10 +2,34 @@
 
 import { describe, expect, it } from "vitest";
 
-import { RECIPE_IMPORT_PROCESSING_TIMEOUT_MS } from "@norish/queue/config";
+import {
+  allergyDetectionJobOptions,
+  autoCategorizationJobOptions,
+  autoTaggingJobOptions,
+  caldavSyncJobOptions,
+  imageImportJobOptions,
+  nutritionEstimationJobOptions,
+  pasteImportJobOptions,
+  RECIPE_IMPORT_PROCESSING_TIMEOUT_MS,
+  recipeImportJobOptions,
+} from "@norish/queue/config";
 
 describe("Queue config", () => {
   it("sets a max processing time for recipe import jobs", () => {
     expect(RECIPE_IMPORT_PROCESSING_TIMEOUT_MS).toBe(30 * 60 * 1000);
+  });
+
+  it.each([
+    ["recipe import", recipeImportJobOptions],
+    ["image import", imageImportJobOptions],
+    ["paste import", pasteImportJobOptions],
+    ["CalDAV sync", caldavSyncJobOptions],
+    ["nutrition estimation", nutritionEstimationJobOptions],
+    ["auto-tagging", autoTaggingJobOptions],
+    ["auto-categorization", autoCategorizationJobOptions],
+    ["allergy detection", allergyDetectionJobOptions],
+  ])("releases deterministic IDs after %s jobs reach a terminal state", (_name, options) => {
+    expect(options.removeOnComplete).toBe(true);
+    expect(options.removeOnFail).toBe(true);
   });
 });

--- a/packages/queue/src/config.ts
+++ b/packages/queue/src/config.ts
@@ -72,14 +72,22 @@ export const WORKER_CONCURRENCY = {
 
 export const RECIPE_IMPORT_PROCESSING_TIMEOUT_MS = 30 * 60 * 1000;
 
+/**
+ * Deterministic job IDs should only deduplicate jobs while they are in flight.
+ * Removing terminal jobs releases the ID so the same operation can be run again.
+ */
+const rerunnableJobCleanupOptions = {
+  removeOnComplete: true,
+  removeOnFail: true,
+} satisfies Pick<DefaultJobOptions, "removeOnComplete" | "removeOnFail">;
+
 export const recipeImportJobOptions: DefaultJobOptions = {
   attempts: 3,
   backoff: {
     type: "exponential",
     delay: 2000, // 2s, 4s, 8s
   },
-  removeOnComplete: true,
-  removeOnFail: true,
+  ...rerunnableJobCleanupOptions,
 };
 
 export const imageImportJobOptions: DefaultJobOptions = {
@@ -88,11 +96,7 @@ export const imageImportJobOptions: DefaultJobOptions = {
     type: "exponential",
     delay: 5000, // 5s, 10s
   },
-  removeOnComplete: {
-    age: 3600,
-    count: 500,
-  },
-  removeOnFail: true,
+  ...rerunnableJobCleanupOptions,
 };
 
 export const pasteImportJobOptions: DefaultJobOptions = {
@@ -101,11 +105,7 @@ export const pasteImportJobOptions: DefaultJobOptions = {
     type: "exponential",
     delay: 2000,
   },
-  removeOnComplete: {
-    age: 3600,
-    count: 1000,
-  },
-  removeOnFail: true,
+  ...rerunnableJobCleanupOptions,
 };
 
 export const caldavSyncJobOptions: DefaultJobOptions = {
@@ -114,14 +114,7 @@ export const caldavSyncJobOptions: DefaultJobOptions = {
     type: "exponential",
     delay: 60000, // 1m, 2m, 4m, 8m... up to 17h
   },
-  removeOnComplete: {
-    age: 3600,
-    count: 2000,
-  },
-  removeOnFail: {
-    age: 86400, // Failed state also persisted to Postgres
-    count: 1000,
-  },
+  ...rerunnableJobCleanupOptions,
 };
 
 export const scheduledTasksJobOptions: DefaultJobOptions = {
@@ -146,11 +139,7 @@ export const nutritionEstimationJobOptions: DefaultJobOptions = {
     type: "exponential",
     delay: 2000, // 2s, 4s, 8s
   },
-  removeOnComplete: {
-    age: 3600,
-    count: 500,
-  },
-  removeOnFail: true,
+  ...rerunnableJobCleanupOptions,
 };
 
 export const autoTaggingJobOptions: DefaultJobOptions = {
@@ -159,11 +148,7 @@ export const autoTaggingJobOptions: DefaultJobOptions = {
     type: "exponential",
     delay: 2000, // 2s, 4s, 8s
   },
-  removeOnComplete: {
-    age: 3600,
-    count: 500,
-  },
-  removeOnFail: true,
+  ...rerunnableJobCleanupOptions,
 };
 
 export const autoCategorizationJobOptions: DefaultJobOptions = {
@@ -172,11 +157,7 @@ export const autoCategorizationJobOptions: DefaultJobOptions = {
     type: "exponential",
     delay: 2000, // 2s, 4s, 8s
   },
-  removeOnComplete: {
-    age: 3600,
-    count: 500,
-  },
-  removeOnFail: true,
+  ...rerunnableJobCleanupOptions,
 };
 
 export const allergyDetectionJobOptions: DefaultJobOptions = {
@@ -185,9 +166,5 @@ export const allergyDetectionJobOptions: DefaultJobOptions = {
     type: "exponential",
     delay: 2000, // 2s, 4s, 8s
   },
-  removeOnComplete: {
-    age: 3600,
-    count: 500,
-  },
-  removeOnFail: true,
+  ...rerunnableJobCleanupOptions,
 };


### PR DESCRIPTION
Rerunning a job that uses a deterministic ID silently did nothing. Several producers use deterministic job IDs and treat only waiting, active, or delayed jobs as duplicates, but their queue defaults kept completed jobs around for up to an hour. BullMQ deduplicates `add()` against a retained completed job ID, so a user-triggered rerun returned the old job while the log claimed a new one had been queued.

The fix removes terminal jobs (`removeOnComplete: true`, `removeOnFail: true`) for the rerunnable queues and centralizes that cleanup policy in one place. Deterministic IDs still reject genuinely concurrent duplicates; removing terminal jobs just frees the ID for an explicit later rerun. An alternative would have been timestamping job IDs, but that would give up in-flight deduplication.

Queues covered: recipe import (which already removed terminal jobs), image recipe import, paste recipe import, CalDAV sync, nutrition estimation, auto-tagging, auto-categorization, and allergy detection. Scheduled tasks are unchanged because they use BullMQ repeat jobs and intentionally keep a short audit history. CalDAV terminal failures are already persisted to PostgreSQL, so nothing is lost by dropping the BullMQ record.

Regression tests cover every deterministic rerunnable queue configuration.

Verification: `pnpm install --frozen-lockfile`, queue typecheck, queue tests (13 files, 85 tests), queue lint and formatting, and repository `pnpm test:run` all pass. Repository-wide `pnpm typecheck` fails on pre-existing `@norish/db` Zod type errors unrelated to this change.