### PR TITLE
Fix groceries store selector

### DIFF
--- a/apps/web/components/Panel/Panel.tsx
+++ b/apps/web/components/Panel/Panel.tsx
@@ -30,10 +30,17 @@ const PanelContext = createContext<{
   open: boolean;
   close: () => void;
   toggle: () => void;
-}>({ open: false, close: () => {}, toggle: () => {} });
+  overlayContainer: HTMLElement | null;
+}>({ open: false, close: () => {}, toggle: () => {}, overlayContainer: null });
 
 export function usePanel() {
   return useContext(PanelContext);
+}
+
+// Drawer sets pointer-events:none on the body, so anything portalled to the body swallows clicks.
+// Pass the overlay container for portals to render inside the drawer.
+export function usePanelOverlayContainer() {
+  return useContext(PanelContext).overlayContainer ?? undefined;
 }
 
 type PanelSectionProps = {
@@ -85,6 +92,7 @@ const PanelRoot: React.FC<PanelProps> = ({
   onOpenChange,
 }) => {
   const [internalOpen, setInternalOpen] = useState(false);
+  const [overlayContainer, setOverlayContainer] = useState<HTMLElement | null>(null);
   const isControlled = controlledOpen !== undefined;
   const open = isControlled ? controlledOpen : internalOpen;
 
@@ -156,7 +164,7 @@ const PanelRoot: React.FC<PanelProps> = ({
     <div data-panel className={className}>
       {trigger && <span className="inline-flex">{triggerElement}</span>}
 
-      <PanelContext.Provider value={{ open, close, toggle }}>
+      <PanelContext.Provider value={{ open, close, toggle, overlayContainer }}>
         {/* repositionInputs resizes the sheet and force-scrolls the focused field to
             the top of its scroll container on iOS, which throws a scrolled panel body
             out of view; Radix's RemoveScroll still locks the page behind the sheet. */}
@@ -170,6 +178,7 @@ const PanelRoot: React.FC<PanelProps> = ({
               data-variant={backdropVariant}
             />
             <Drawer.Content
+              ref={setOverlayContainer}
               aria-describedby={undefined}
               aria-label={title || "Panel"}
               className={twMerge(

--- a/apps/web/components/groceries/store-selector.tsx
+++ b/apps/web/components/groceries/store-selector.tsx
@@ -2,6 +2,7 @@
 
 import type { Key } from "react";
 import { useMemo } from "react";
+import { usePanelOverlayContainer } from "@/components/Panel/Panel";
 import { Label, ListBox, Select } from "@heroui/react";
 
 import type { StoreColor, StoreDto } from "@norish/shared/contracts";
@@ -38,6 +39,7 @@ export function StoreSelector({
   noStoreDescription,
   showWhenEmpty = false,
 }: StoreSelectorProps) {
+  const overlayContainer = usePanelOverlayContainer();
   const sortedStores = useMemo(
     () => [...stores].sort((a, b) => a.sortOrder - b.sortOrder),
     [stores]
@@ -69,7 +71,7 @@ export function StoreSelector({
         <Select.Value className="flex items-center" />
         <Select.Indicator />
       </Select.Trigger>
-      <Select.Popover>
+      <Select.Popover UNSTABLE_portalContainer={overlayContainer}>
         <ListBox>
           <ListBox.Item id="none" textValue={noStoreDescription ?? noStoreLabel}>
             <div className="flex items-center gap-2">

--- a/packages/trpc/src/routers/groceries/groceries-helpers.ts
+++ b/packages/trpc/src/routers/groceries/groceries-helpers.ts
@@ -117,7 +117,8 @@ export async function createGroceriesData(
       storeId: string | null;
     };
   }> = [];
-  const groceriesToUpdate: Array<{ id: string; amount: number | null }> = [];
+  const groceriesToUpdate: Array<{ id: string; amount: number | null; storeId?: string | null }> =
+    [];
   const returnIds: string[] = [];
 
   for (const grocery of input) {
@@ -135,9 +136,19 @@ export async function createGroceriesData(
       const newAmount = grocery.amount ?? 1;
       const mergedAmount = existingAmount + newAmount;
 
-      groceriesToUpdate.push({ id: existing.id, amount: mergedAmount });
+      const mergedStoreId = grocery.storeId ?? existing.storeId;
+
+      groceriesToUpdate.push({
+        id: existing.id,
+        amount: mergedAmount,
+        storeId: mergedStoreId,
+      });
       returnIds.push(existing.id);
-      existingByKey.set(lookupKey!, { ...existing, amount: mergedAmount });
+      existingByKey.set(lookupKey!, {
+        ...existing,
+        amount: mergedAmount,
+        storeId: mergedStoreId,
+      });
       continue;
     }
 


### PR DESCRIPTION
## Description

Selecting a store when adding/editing a grocery was not working.

The Vaul drawer component sets pointer events on body to none while open and the store selection pop over was portalled to document body by default.


## Related Issue(s)

<!-- Link to the related issue(s) this PR addresses -->

Fixes #

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] Other (please describe):

## Screenshots (if applicable)

## Checklist

<!-- Mark the appropriate options with an "x" -->

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

<!-- Add any other context about the PR here -->
