### PR TITLE
chore(video): bump bundled yt-dlp to 2026.08.19

### DIFF
--- a/apps/docs/docs/configuration/ai-provider.md
+++ b/apps/docs/docs/configuration/ai-provider.md
@@ -263,7 +263,7 @@ site imports as a regular webpage.
 | -------------------------- | -------------------------------------------------------------------------------------------- | ----------------------------------------- |
 | `VIDEO_PARSING_ENABLED`    | Enable the video parsing pipeline                                                            | `false`                                   |
 | `VIDEO_MAX_LENGTH_SECONDS` | Maximum accepted video length                                                                | `120`                                     |
-| `YT_DLP_VERSION`           | yt-dlp release a development install downloads on first use (the Docker image ships its own) | `2026.07.04`                              |
+| `YT_DLP_VERSION`           | yt-dlp release a development install downloads on first use (the Docker image ships its own) | `2026.08.19`                              |
 | `YT_DLP_BIN_DIR`           | Folder containing the yt-dlp binary                                                          | `./.runtime/bin` (dev), `/app/bin` (prod) |
 | `YT_DLP_PROXY`             | HTTP/SOCKS proxy URL for yt-dlp downloads                                                    | (empty)                                   |
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -167,7 +167,7 @@ FROM base AS ytdlp
 # Keep in step with DEFAULT_YT_DLP_VERSION in packages/config/src/zod/server-config.ts:
 # this is the binary the image actually ships, and that constant is the version
 # the server reports for it.
-ARG YT_DLP_VERSION=2026.07.04
+ARG YT_DLP_VERSION=2026.08.19
 ARG TARGETARCH
 
 RUN apk add --no-cache curl

--- a/packages/config/src/zod/server-config.ts
+++ b/packages/config/src/zod/server-config.ts
@@ -475,7 +475,7 @@ export function transcriptionProviderSupportsModelListing(
  * Sites that break as a site changes (Instagram most of all) are fixed in yt-dlp
  * releases, so this trails the newest release rather than leading it.
  */
-export const DEFAULT_YT_DLP_VERSION = "2026.07.04";
+export const DEFAULT_YT_DLP_VERSION = "2026.08.19";
 
 export const VideoConfigSchema = z.object({
   enabled: z.boolean(),


### PR DESCRIPTION
## Description

TikTok recipe imports currently fail at the metadata-probe step: the bundled
yt-dlp binary (pinned to `2026.07.04`) cannot extract anything from TikTok
URLs. This bumps the pinned yt-dlp version to `2026.08.19`, whose changelog
fixes exactly this.

## Related Issue(s)

Fixes #545

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Problem

On a self-hosted instance running `norishapp/norish:latest` (image built
2026-07-17, bundled yt-dlp `2026.07.04`), importing a recipe from a
`vm.tiktok.com` share URL fails on every attempt (3/3 BullMQ retries) at the
metadata-probe step. Instagram imports on the same instance succeed.

Running the bundled yt-dlp directly against the same URL reproduces it
outside of Norish:

```
$ yt-dlp --dump-json https://vm.tiktok.com/ZGdQ8PJFR/
ERROR: [TikTok] 7678753725300624672: Unexpected response from webpage request
```

## Cause

yt-dlp's TikTok extractor was broken as of the `2026.07.04` release that
Norish's Docker image pins (`docker/Dockerfile` `ARG YT_DLP_VERSION`, kept in
step with `DEFAULT_YT_DLP_VERSION` in
`packages/config/src/zod/server-config.ts`).

[yt-dlp `2026.08.19`](https://github.com/yt-dlp/yt-dlp/releases/tag/2026.08.19)
fixes this directly — its changelog includes:

- `tiktok: Fix extractor`
- `tiktok: Fix formats extraction`
- `tiktok: Support share URLs`

## Repro (before / after)

Same URL, same machine, only the yt-dlp binary version differs:

**Before (yt-dlp 2026.07.04, the version currently pinned):**

```
$ yt-dlp --dump-json https://vm.tiktok.com/ZGdQ8PJFR/
ERROR: [TikTok] 7678753725300624672: Unexpected response from webpage request
```

**After (yt-dlp 2026.08.19, this PR's pinned version):**

```
$ yt-dlp --dump-json https://vm.tiktok.com/ZGdQ8PJFR/
{"title": "...", "uploader": "...", "duration": 39, "formats": [ ...12 formats... ]}
```

Title/uploader/exact duration omitted here as they belong to a third party's
public post; the successful run returned a complete metadata payload with 12
available formats, versus a hard failure before the bump.

## Files Changed

- `docker/Dockerfile` — `ARG YT_DLP_VERSION` `2026.07.04` → `2026.08.19`
- `packages/config/src/zod/server-config.ts` — `DEFAULT_YT_DLP_VERSION`
  `2026.07.04` → `2026.08.19`
- `apps/docs/docs/configuration/ai-provider.md` — documented default for
  `YT_DLP_VERSION` updated to match

These are the two locations the repo's own alignment test
(`packages/config/__tests__/config/yt-dlp-version.test.ts`) checks for
consistency, plus the one live docs page that documents the same default.
Versioned docs snapshots under `apps/docs/versioned_docs/` were intentionally
left untouched (frozen historical releases, per
`docs/adr/releases/0010-release-notes-use-a-release-checkpoint.md`), and the
`2026.07.04` literals in
`packages/trpc/__tests__/admin/video-runtime.test.ts` were also left as-is —
they're arbitrary example strings for a mocked runtime lookup, unrelated to
`DEFAULT_YT_DLP_VERSION`.

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] Other (please describe):

- `pnpm --filter @norish/config run test` — full package suite passes,
  including `packages/config/__tests__/config/yt-dlp-version.test.ts` (3/3),
  which asserts the Dockerfile `ARG` and `SERVER_CONFIG.YT_DLP_VERSION` both
  match `DEFAULT_YT_DLP_VERSION`.
- `packages/trpc/__tests__/admin/video-runtime.test.ts` — unaffected, 3/3
  still passing (confirms the unrelated `2026.07.04` mock literals didn't
  need touching).
- `pnpm exec prettier --check` on the two non-Dockerfile files touched — no
  formatting drift.
- Confirmed the release assets the Dockerfile downloads
  (`yt-dlp_musllinux`, `yt-dlp_musllinux_aarch64`) exist for the
  `2026.08.19` tag.
- Manual repro of the TikTok import failure and its fix, described above,
  run against the actual yt-dlp binaries (`2026.07.04` vs `2026.08.19`)
  outside of Norish, isolating the change to the yt-dlp extractor rather
  than anything in Norish's own import pipeline.

## Additional Notes

#413 ("issue uploading tiktok recipes") looked related at a glance but is a
different problem (permissions), so it is not referenced as related.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
