### PR TITLE
Bulk-clear the grocery list

### DIFF
--- a/apps/web/__tests__/components/groceries/clear-groceries-modal.test.tsx
+++ b/apps/web/__tests__/components/groceries/clear-groceries-modal.test.tsx
@@ -1,0 +1,117 @@
+import { ClearGroceriesModal } from "@/components/groceries/clear-groceries-modal";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import "@testing-library/jest-dom";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string, params?: Record<string, unknown>) =>
+    params ? `${key} ${Object.values(params).join(" ")}` : key,
+}));
+
+vi.mock("@heroui/react", () => {
+  const Passthrough = ({ children }: { children?: React.ReactNode }) => <div>{children}</div>;
+
+  return {
+    Button: ({ children, onPress }: { children?: React.ReactNode; onPress?: () => void }) => (
+      <button type="button" onClick={onPress}>
+        {children}
+      </button>
+    ),
+    Modal: {
+      Backdrop: ({ children, isOpen }: { children?: React.ReactNode; isOpen: boolean }) =>
+        isOpen ? <div>{children}</div> : null,
+      Container: Passthrough,
+      Dialog: Passthrough,
+      Header: Passthrough,
+      Body: Passthrough,
+      Footer: Passthrough,
+    },
+  };
+});
+
+describe("ClearGroceriesModal", () => {
+  it("shows the whole-list copy when scopeName is null", () => {
+    render(
+      <ClearGroceriesModal
+        isOpen
+        itemCount={5}
+        scopeName={null}
+        onClose={vi.fn()}
+        onConfirm={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("listTitle")).toBeInTheDocument();
+    expect(screen.getByText("listDescription 5")).toBeInTheDocument();
+  });
+
+  it("shows the named-scope copy when scopeName is set", () => {
+    render(
+      <ClearGroceriesModal
+        isOpen
+        itemCount={3}
+        scopeName="Costco"
+        onClose={vi.fn()}
+        onConfirm={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("sectionTitle")).toBeInTheDocument();
+    expect(screen.getByText("sectionDescription Costco 3")).toBeInTheDocument();
+  });
+
+  it("fires onConfirm and onClose when confirmed", () => {
+    const onConfirm = vi.fn();
+    const onClose = vi.fn();
+
+    render(
+      <ClearGroceriesModal
+        isOpen
+        itemCount={1}
+        scopeName={null}
+        onClose={onClose}
+        onConfirm={onConfirm}
+      />
+    );
+
+    fireEvent.click(screen.getByText("confirm"));
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires only onClose when cancelled", () => {
+    const onConfirm = vi.fn();
+    const onClose = vi.fn();
+
+    render(
+      <ClearGroceriesModal
+        isOpen
+        itemCount={1}
+        scopeName={null}
+        onClose={onClose}
+        onConfirm={onConfirm}
+      />
+    );
+
+    fireEvent.click(screen.getByText("cancel"));
+
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders nothing when closed", () => {
+    render(
+      <ClearGroceriesModal
+        isOpen={false}
+        itemCount={1}
+        scopeName={null}
+        onClose={vi.fn()}
+        onConfirm={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByText("listTitle")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/__tests__/components/groceries/store-heading.test.tsx
+++ b/apps/web/__tests__/components/groceries/store-heading.test.tsx
@@ -1,0 +1,94 @@
+import { StoreHeading } from "@/components/groceries/store-heading";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import "@testing-library/jest-dom";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+  useLocale: () => "en",
+}));
+
+vi.mock("motion/react", () => ({
+  motion: new Proxy(
+    {},
+    {
+      get:
+        () =>
+        ({ children, ...rest }: { children?: React.ReactNode }) => <div {...rest}>{children}</div>,
+    }
+  ),
+}));
+
+vi.mock("@heroui/react", () => {
+  const Passthrough = ({ children }: { children?: React.ReactNode }) => <>{children}</>;
+  const Dropdown = ({ children }: { children?: React.ReactNode }) => <div>{children}</div>;
+
+  Dropdown.Popover = Passthrough;
+  Dropdown.Menu = Passthrough;
+  Dropdown.Item = ({ children, onPress }: { children?: React.ReactNode; onPress?: () => void }) => (
+    <button type="button" onClick={onPress}>
+      {children}
+    </button>
+  );
+  Dropdown.Section = Passthrough;
+
+  return {
+    Button: ({ children, onPress }: { children?: React.ReactNode; onPress?: () => void }) => (
+      <button type="button" onClick={onPress}>
+        {children}
+      </button>
+    ),
+    Dropdown,
+    Label: Passthrough,
+    Separator: () => <hr />,
+  };
+});
+
+function renderHeading(props: Partial<React.ComponentProps<typeof StoreHeading>> = {}) {
+  return render(
+    <StoreHeading
+      activeCount={2}
+      doneCount={0}
+      expanded
+      name="Costco"
+      onExpandedChange={vi.fn()}
+      {...props}
+    />
+  );
+}
+
+describe("StoreHeading", () => {
+  it("renders no kebab when actions is absent", () => {
+    renderHeading();
+
+    // Only the expand toggle button, no Dropdown trigger.
+    expect(screen.getAllByRole("button")).toHaveLength(1);
+  });
+
+  it("hides Mark all done and Delete done when their handlers are absent", () => {
+    renderHeading({ actions: { onClearAll: vi.fn() } });
+
+    expect(screen.queryByText("markAllDone")).not.toBeInTheDocument();
+    expect(screen.queryByText("deleteDone")).not.toBeInTheDocument();
+    expect(screen.getByText("clearAll")).toBeInTheDocument();
+  });
+
+  it("shows Clear all only when onClearAll is passed", () => {
+    renderHeading({ actions: { onMarkAllDone: vi.fn(), onDeleteDone: vi.fn() } });
+
+    expect(screen.getByText("markAllDone")).toBeInTheDocument();
+    expect(screen.getByText("deleteDone")).toBeInTheDocument();
+    expect(screen.queryByText("clearAll")).not.toBeInTheDocument();
+  });
+
+  it("fires onClearAll when Clear all is pressed", () => {
+    const onClearAll = vi.fn();
+
+    renderHeading({ actions: { onClearAll } });
+
+    fireEvent.click(screen.getByText("clearAll"));
+
+    expect(onClearAll).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/app/(app)/groceries/components/groceries-page.tsx
+++ b/apps/web/app/(app)/groceries/components/groceries-page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { useState } from "react";
 import { GroceryList, GroceryListByRecipe, StoreManagerPanel } from "@/components/groceries";
+import { ClearGroceriesModal } from "@/components/groceries/clear-groceries-modal";
 import { AddGroceryPanel } from "@/components/Panel/consumers";
 import EditGroceryPanel from "@/components/Panel/consumers/edit-grocery-panel";
 import UiSwitch from "@/components/shared/ui-switch";
@@ -11,6 +13,7 @@ import {
   CheckIcon,
   Cog6ToothIcon,
   PlusIcon,
+  TrashIcon,
 } from "@heroicons/react/16/solid";
 import { Button, Dropdown, Header, Label, Separator } from "@heroui/react";
 import { useTranslations } from "next-intl";
@@ -54,6 +57,31 @@ export function GroceriesPage() {
     setGroupSimilarIngredients,
   } = useGroceriesUiContext();
   const t = useTranslations("groceries.page");
+
+  type ClearScope =
+    | { kind: "all" }
+    | { kind: "store"; storeId: string | null; name: string }
+    | { kind: "recipe"; ids: string[]; name: string };
+  const [clearScope, setClearScope] = useState<ClearScope | null>(null);
+  const handleClearConfirm = () => {
+    if (!clearScope) return;
+    if (clearScope.kind === "all") {
+      deleteGroceries(groceries.map((g) => g.id));
+    } else if (clearScope.kind === "store") {
+      deleteGroceries(groceries.filter((g) => g.storeId === clearScope.storeId).map((g) => g.id));
+    } else {
+      deleteGroceries(clearScope.ids);
+    }
+  };
+  const clearItemCount =
+    clearScope?.kind === "all"
+      ? groceries.length
+      : clearScope?.kind === "store"
+        ? groceries.filter((g) => g.storeId === clearScope.storeId).length
+        : (clearScope?.ids.length ?? 0);
+  const clearScopeName =
+    clearScope?.kind === "store" || clearScope?.kind === "recipe" ? clearScope.name : null;
+
   const handleToggle = (id: string, isDone: boolean) => {
     toggleGroceries([id], isDone);
   };
@@ -210,6 +238,19 @@ export function GroceriesPage() {
                       {<Cog6ToothIcon className="h-4 w-4" />}
                       <Label>{t("manageStores")}</Label>
                     </Dropdown.Item>
+                    {groceries.length > 0 && (
+                      <Dropdown.Item
+                        key="clear-list"
+                        className="text-danger"
+                        id="clear-list"
+                        textValue={t("clearList")}
+                        variant="danger"
+                        onPress={() => setClearScope({ kind: "all" })}
+                      >
+                        {<TrashIcon className="h-4 w-4" />}
+                        <Label>{t("clearList")}</Label>
+                      </Dropdown.Item>
+                    )}
                   </Dropdown.Section>
                 </Dropdown.Menu>
               </Dropdown.Popover>
@@ -226,6 +267,7 @@ export function GroceriesPage() {
               groupSimilarIngredients={groupSimilarIngredients}
               recurringGroceries={recurringGroceries}
               stores={stores}
+              onClearAllInStore={(storeId, name) => setClearScope({ kind: "store", storeId, name })}
               onDelete={handleDelete}
               onDeleteDoneInStore={deleteDoneInStore}
               onEdit={handleEdit}
@@ -240,6 +282,7 @@ export function GroceriesPage() {
               recipeMap={recipeMap}
               recurringGroceries={recurringGroceries}
               stores={stores}
+              onClearRecipe={(ids, name) => setClearScope({ kind: "recipe", ids, name })}
               onDelete={handleDelete}
               onEdit={handleEdit}
               onReorder={reorderGroceriesInStore}
@@ -288,6 +331,14 @@ export function GroceriesPage() {
           onSave={handleEditSave}
         />
       )}
+
+      <ClearGroceriesModal
+        isOpen={clearScope !== null}
+        itemCount={clearItemCount}
+        scopeName={clearScopeName}
+        onClose={() => setClearScope(null)}
+        onConfirm={handleClearConfirm}
+      />
     </>
   );
 }

--- a/apps/web/components/groceries/clear-groceries-modal.tsx
+++ b/apps/web/components/groceries/clear-groceries-modal.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { Button, Modal } from "@heroui/react";
+import { useTranslations } from "next-intl";
+
+interface ClearGroceriesModalProps {
+  isOpen: boolean;
+  itemCount: number;
+  /** null clears the whole list; otherwise the Store's, Unsorted's or a recipe's name. */
+  scopeName: string | null;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+export function ClearGroceriesModal({
+  isOpen,
+  itemCount,
+  scopeName,
+  onClose,
+  onConfirm,
+}: ClearGroceriesModalProps) {
+  const t = useTranslations("groceries.clearConfirm");
+  const tActions = useTranslations("common.actions");
+  const handleConfirm = () => {
+    onConfirm();
+    onClose();
+  };
+
+  return (
+    <Modal.Backdrop isOpen={isOpen} onOpenChange={onClose}>
+      <Modal.Container>
+        <Modal.Dialog>
+          <Modal.Header>{scopeName === null ? t("listTitle") : t("sectionTitle")}</Modal.Header>
+          <Modal.Body>
+            <p className="text-muted text-base">
+              {scopeName === null
+                ? t("listDescription", { count: itemCount })
+                : t("sectionDescription", { name: scopeName, count: itemCount })}
+            </p>
+          </Modal.Body>
+          <Modal.Footer>
+            <Button variant="tertiary" onPress={onClose}>
+              {tActions("cancel")}
+            </Button>
+            <Button variant="danger" onPress={handleConfirm}>
+              {t("confirm")}
+            </Button>
+          </Modal.Footer>
+        </Modal.Dialog>
+      </Modal.Container>
+    </Modal.Backdrop>
+  );
+}

--- a/apps/web/components/groceries/grocery-list-by-recipe.tsx
+++ b/apps/web/components/groceries/grocery-list-by-recipe.tsx
@@ -26,6 +26,7 @@ interface GroceryListByRecipeProps {
   onEdit: (grocery: GroceryDto) => void;
   onDelete: (id: string) => void;
   onReorder?: (updates: { id: string; sortOrder: number }[]) => void;
+  onClearRecipe?: (ids: string[], name: string) => void;
 }
 
 interface RecipeGroup {
@@ -43,6 +44,7 @@ export function GroceryListByRecipe({
   onEdit,
   onDelete,
   onReorder,
+  onClearRecipe,
 }: GroceryListByRecipeProps) {
   const t = useTranslations("groceries");
 
@@ -148,6 +150,12 @@ export function GroceryListByRecipe({
             recipeName={group.recipeName}
             recurringGroceries={recurringGroceries}
             stores={stores}
+            onClearRecipe={() =>
+              onClearRecipe?.(
+                group.groceries.map((g) => g.id),
+                group.recipeName
+              )
+            }
             onDelete={onDelete}
             onEdit={onEdit}
             onReorder={onReorder}

--- a/apps/web/components/groceries/grocery-list.tsx
+++ b/apps/web/components/groceries/grocery-list.tsx
@@ -30,6 +30,7 @@ interface GroceryListProps {
   ) => void;
   onMarkAllDoneInStore?: (storeId: string | null) => void;
   onDeleteDoneInStore?: (storeId: string | null) => void;
+  onClearAllInStore?: (storeId: string | null, storeName: string) => void;
   getRecipeNameForGrocery?: (grocery: GroceryDto) => string | null;
   /** Whether to group similar ingredients together */
   groupSimilarIngredients?: boolean;
@@ -46,10 +47,12 @@ export function GroceryList({
   onReorderInStore,
   onMarkAllDoneInStore,
   onDeleteDoneInStore,
+  onClearAllInStore,
   getRecipeNameForGrocery,
   groupSimilarIngredients = false,
 }: GroceryListProps) {
   const t = useTranslations("groceries.empty");
+  const tStore = useTranslations("groceries.store");
   const { units: customUnits } = useUnitsQuery();
   // Where each Store files each name — the one place a grocery's aisle comes
   // from (ADR-0031) — and the one write a drop into an aisle makes.
@@ -165,6 +168,7 @@ export function GroceryList({
                 groups={ingredientGroups.get(null) ?? []}
                 recurringGroceries={recurringGroceries}
                 store={null}
+                onClearAll={() => onClearAllInStore?.(null, tStore("unsorted"))}
                 onDelete={onDelete}
                 onDeleteDone={() => onDeleteDoneInStore?.(null)}
                 onEdit={onEdit}
@@ -195,6 +199,7 @@ export function GroceryList({
                   groups={storeGroups}
                   recurringGroceries={recurringGroceries}
                   store={store}
+                  onClearAll={() => onClearAllInStore?.(store.id, store.name)}
                   onDelete={onDelete}
                   onDeleteDone={() => onDeleteDoneInStore?.(store.id)}
                   onEdit={onEdit}
@@ -238,6 +243,7 @@ export function GroceryList({
               groceries={unsortedGroceries}
               recurringGroceries={recurringGroceries}
               store={null}
+              onClearAll={() => onClearAllInStore?.(null, tStore("unsorted"))}
               onDelete={onDelete}
               onDeleteDone={() => onDeleteDoneInStore?.(null)}
               onEdit={onEdit}
@@ -263,6 +269,7 @@ export function GroceryList({
               groceries={storeGroceries}
               recurringGroceries={recurringGroceries}
               store={store}
+              onClearAll={() => onClearAllInStore?.(store.id, store.name)}
               onDelete={onDelete}
               onDeleteDone={() => onDeleteDoneInStore?.(store.id)}
               onEdit={onEdit}

--- a/apps/web/components/groceries/grouped-store-section.tsx
+++ b/apps/web/components/groceries/grouped-store-section.tsx
@@ -37,6 +37,7 @@ interface GroupedStoreSectionProps {
   defaultExpanded?: boolean;
   onMarkAllDone?: () => void;
   onDeleteDone?: () => void;
+  onClearAll?: () => void;
 }
 
 /**
@@ -57,6 +58,7 @@ function GroupedStoreSectionComponent({
   defaultExpanded = true,
   onMarkAllDone,
   onDeleteDone,
+  onClearAll,
 }: GroupedStoreSectionProps) {
   const [isExpanded, setIsExpanded] = useState(defaultExpanded);
   const t = useTranslations("groceries.store");
@@ -147,7 +149,7 @@ function GroupedStoreSectionComponent({
   // The heading, handed to the container so a drop on it lands in the Store
   const headerElement = (
     <StoreHeading
-      actions={groceries.length > 0 ? { onMarkAllDone, onDeleteDone } : undefined}
+      actions={groceries.length > 0 ? { onMarkAllDone, onDeleteDone, onClearAll } : undefined}
       activeCount={activeCount}
       doneCount={doneCount}
       dot={store !== null}

--- a/apps/web/components/groceries/recipe-section.tsx
+++ b/apps/web/components/groceries/recipe-section.tsx
@@ -19,6 +19,7 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { motion } from "motion/react";
+import { useTranslations } from "next-intl";
 
 import type { GroceryDto, RecurringGroceryDto, StoreDto } from "@norish/shared/contracts";
 
@@ -55,6 +56,7 @@ interface RecipeSectionProps {
   onEdit: (grocery: GroceryDto) => void;
   onDelete: (id: string) => void;
   onReorder?: (updates: { id: string; sortOrder: number }[]) => void;
+  onClearRecipe?: () => void;
   defaultExpanded?: boolean;
 }
 
@@ -67,9 +69,11 @@ function RecipeSectionComponent({
   onEdit,
   onDelete,
   onReorder,
+  onClearRecipe,
   defaultExpanded = true,
 }: RecipeSectionProps) {
   const [isExpanded, setIsExpanded] = useState(defaultExpanded);
+  const t = useTranslations("groceries.store");
 
   // Track items that are transitioning (just toggled) - delay their reorder
   const [transitioningIds, setTransitioningIds] = useState<Set<string>>(new Set());
@@ -253,6 +257,8 @@ function RecipeSectionComponent({
     >
       <div className="bg-surface-secondary">
         <StoreHeading
+          actions={onClearRecipe ? { onClearAll: onClearRecipe } : undefined}
+          actionsLabel={t("recipeActions")}
           activeCount={activeCount}
           doneCount={doneCount}
           expanded={isExpanded}

--- a/apps/web/components/groceries/store-heading.tsx
+++ b/apps/web/components/groceries/store-heading.tsx
@@ -7,16 +7,17 @@ import {
   EllipsisVerticalIcon,
   TrashIcon,
 } from "@heroicons/react/16/solid";
-import { Button, Dropdown, Label } from "@heroui/react";
+import { Button, Dropdown, Label, Separator } from "@heroui/react";
 import { motion } from "motion/react";
 import { useLocale, useTranslations } from "next-intl";
 
 import type { StoreTotal } from "./store-total";
 
-/** Mark all done and Delete done: what a section's kebab holds, and all it holds. */
+/** Mark all done, Delete done and Clear all: what a section's kebab can hold. */
 export interface StoreHeadingActions {
   onMarkAllDone?: () => void;
   onDeleteDone?: () => void;
+  onClearAll?: () => void;
 }
 
 interface StoreHeadingProps {
@@ -32,6 +33,8 @@ interface StoreHeadingProps {
   onExpandedChange: (expanded: boolean) => void;
   /** The kebab's actions; absent where the section has no kebab, as a recipe's has not. */
   actions?: StoreHeadingActions;
+  /** The kebab's accessible label; defaults to "Store actions" so a recipe section can say "Recipe actions" instead. */
+  actionsLabel?: string;
   /** What the drag helpers find a Store's heading by; a recipe section is no drop target. */
   dropTarget?: string;
 }
@@ -57,6 +60,7 @@ export function StoreHeading({
   expanded,
   onExpandedChange,
   actions,
+  actionsLabel,
   dropTarget,
 }: StoreHeadingProps) {
   const t = useTranslations("groceries.store");
@@ -128,27 +132,53 @@ export function StoreHeading({
             <EllipsisVerticalIcon className="h-5 w-5" />
           </Button>
           <Dropdown.Popover className="bg-overlay">
-            <Dropdown.Menu aria-label={t("storeActions")}>
-              <Dropdown.Item
-                key="mark-done"
-                id="mark-done"
-                textValue={t("markAllDone")}
-                onPress={() => actions.onMarkAllDone?.()}
-              >
-                {<CheckIcon className="h-4 w-4" />}
-                <Label>{t("markAllDone")}</Label>
-              </Dropdown.Item>
-              <Dropdown.Item
-                key="delete-done"
-                className="text-danger"
-                id="delete-done"
-                textValue={t("deleteDone")}
-                variant="danger"
-                onPress={() => actions.onDeleteDone?.()}
-              >
-                {<TrashIcon className="h-4 w-4" />}
-                <Label>{t("deleteDone")}</Label>
-              </Dropdown.Item>
+            <Dropdown.Menu aria-label={actionsLabel ?? t("storeActions")}>
+              {(actions.onMarkAllDone || actions.onDeleteDone) && (
+                <Dropdown.Section>
+                  {actions.onMarkAllDone && (
+                    <Dropdown.Item
+                      key="mark-done"
+                      id="mark-done"
+                      textValue={t("markAllDone")}
+                      onPress={() => actions.onMarkAllDone?.()}
+                    >
+                      {<CheckIcon className="h-4 w-4" />}
+                      <Label>{t("markAllDone")}</Label>
+                    </Dropdown.Item>
+                  )}
+                  {actions.onDeleteDone && (
+                    <Dropdown.Item
+                      key="delete-done"
+                      className="text-danger"
+                      id="delete-done"
+                      textValue={t("deleteDone")}
+                      variant="danger"
+                      onPress={() => actions.onDeleteDone?.()}
+                    >
+                      {<TrashIcon className="h-4 w-4" />}
+                      <Label>{t("deleteDone")}</Label>
+                    </Dropdown.Item>
+                  )}
+                </Dropdown.Section>
+              )}
+              {actions.onClearAll && (
+                <>
+                  {(actions.onMarkAllDone || actions.onDeleteDone) && <Separator />}
+                  <Dropdown.Section>
+                    <Dropdown.Item
+                      key="clear-all"
+                      className="text-danger"
+                      id="clear-all"
+                      textValue={t("clearAll")}
+                      variant="danger"
+                      onPress={() => actions.onClearAll?.()}
+                    >
+                      {<TrashIcon className="h-4 w-4" />}
+                      <Label>{t("clearAll")}</Label>
+                    </Dropdown.Item>
+                  </Dropdown.Section>
+                </>
+              )}
             </Dropdown.Menu>
           </Dropdown.Popover>
         </Dropdown>

--- a/apps/web/components/groceries/store-section.tsx
+++ b/apps/web/components/groceries/store-section.tsx
@@ -36,6 +36,7 @@ interface StoreSectionProps {
   defaultExpanded?: boolean;
   onMarkAllDone?: () => void;
   onDeleteDone?: () => void;
+  onClearAll?: () => void;
   getRecipeNameForGrocery?: (grocery: GroceryDto) => string | null;
 }
 
@@ -53,6 +54,7 @@ function StoreSectionComponent({
   defaultExpanded = true,
   onMarkAllDone,
   onDeleteDone,
+  onClearAll,
   getRecipeNameForGrocery,
 }: StoreSectionProps) {
   const [isExpanded, setIsExpanded] = useState(defaultExpanded);
@@ -191,7 +193,7 @@ function StoreSectionComponent({
   // The heading, handed to the container so a drop on it lands in the Store
   const headerElement = (
     <StoreHeading
-      actions={groceries.length > 0 ? { onMarkAllDone, onDeleteDone } : undefined}
+      actions={groceries.length > 0 ? { onMarkAllDone, onDeleteDone, onClearAll } : undefined}
       activeCount={activeCount}
       doneCount={doneCount}
       dot={store !== null}

--- a/packages/i18n/src/messages/bg/groceries.json
+++ b/packages/i18n/src/messages/bg/groceries.json
@@ -8,7 +8,8 @@
     "viewMode": "Изглед",
     "manageStores": "Управление на магазини",
     "storeViewOptions": "Опции за изглед по магазин",
-    "groupIngredients": "Групиране на съставките"
+    "groupIngredients": "Групиране на съставките",
+    "clearList": "Изчисти списъка"
   },
   "empty": {
     "title": "Списъкът с продукти те очаква",
@@ -23,8 +24,10 @@
   "store": {
     "unsorted": "Некатегоризирани",
     "storeActions": "Действия за магазина",
+    "recipeActions": "Действия за рецептата",
     "markAllDone": "Маркирай всички като изпълнени",
     "deleteDone": "Изтрий изпълнените",
+    "clearAll": "Изчисти всичко",
     "done": "{count} изпълнени",
     "allDone": "Всичко е готово",
     "total": "Остава да купите"
@@ -148,6 +151,13 @@
     "invalidPrice": "Въведете цена, например 2,49",
     "invalidCurrency": "Валутата е три букви, например EUR",
     "openPage": "Отвори в {store}"
+  },
+  "clearConfirm": {
+    "listTitle": "Изчистване на списъка?",
+    "listDescription": "Това ще премахне {count, plural, one {# продукт} other {# продукта}} от списъка за пазаруване. Това действие не може да бъде отменено.",
+    "sectionTitle": "Изчистване на {name}?",
+    "sectionDescription": "Това ще премахне {count, plural, one {# продукт} other {# продукта}} от {name}. Това действие не може да бъде отменено.",
+    "confirm": "Изчисти"
   },
   "price": {
     "pending": "Търсене на цената",

--- a/packages/i18n/src/messages/da/groceries.json
+++ b/packages/i18n/src/messages/da/groceries.json
@@ -8,7 +8,8 @@
     "viewMode": "Visningstilstand",
     "manageStores": "Administrer butikker",
     "storeViewOptions": "Butikvisningsindstillinger",
-    "groupIngredients": "Gruppér ingredienser"
+    "groupIngredients": "Gruppér ingredienser",
+    "clearList": "Ryd listen"
   },
   "empty": {
     "title": "Din indkøbsliste venter",
@@ -23,8 +24,10 @@
   "store": {
     "unsorted": "Usorteret",
     "storeActions": "Butikshandlinger",
+    "recipeActions": "Opskrifthandlinger",
     "markAllDone": "Markér alle som færdige",
     "deleteDone": "Slet færdige",
+    "clearAll": "Ryd alle",
     "done": "{count} færdige",
     "allDone": "Alt færdigt",
     "total": "Mangler at købe"
@@ -148,6 +151,13 @@
     "invalidPrice": "Indtast en pris, f.eks. 2,49",
     "invalidCurrency": "En valuta er tre bogstaver, f.eks. EUR",
     "openPage": "Åbn hos {store}"
+  },
+  "clearConfirm": {
+    "listTitle": "Ryd listen?",
+    "listDescription": "Dette fjerner {count, plural, one {# vare} other {# varer}} fra din indkøbsliste. Dette kan ikke fortrydes.",
+    "sectionTitle": "Ryd {name}?",
+    "sectionDescription": "Dette fjerner {count, plural, one {# vare} other {# varer}} fra {name}. Dette kan ikke fortrydes.",
+    "confirm": "Ryd"
   },
   "price": {
     "pending": "Slår prisen op",

--- a/packages/i18n/src/messages/de-formal/groceries.json
+++ b/packages/i18n/src/messages/de-formal/groceries.json
@@ -8,7 +8,8 @@
     "viewMode": "Ansicht",
     "manageStores": "Geschäfte verwalten",
     "storeViewOptions": "Optionen Geschäftsansicht",
-    "groupIngredients": "Zutaten gruppieren"
+    "groupIngredients": "Zutaten gruppieren",
+    "clearList": "Liste leeren"
   },
   "empty": {
     "title": "Ihre Einkaufsliste wartet",
@@ -23,8 +24,10 @@
   "store": {
     "unsorted": "Unsortiert",
     "storeActions": "Aktionen",
+    "recipeActions": "Rezeptaktionen",
     "markAllDone": "Alle abhaken",
     "deleteDone": "Erledigte löschen",
+    "clearAll": "Alle löschen",
     "done": "{count} erledigt",
     "allDone": "Alles erledigt",
     "total": "Noch zu kaufen"
@@ -148,6 +151,13 @@
     "invalidPrice": "Geben Sie einen Preis ein, z. B. 2,49",
     "invalidCurrency": "Eine Währung besteht aus drei Buchstaben, z. B. EUR",
     "openPage": "Bei {store} öffnen"
+  },
+  "clearConfirm": {
+    "listTitle": "Liste leeren?",
+    "listDescription": "Dadurch werden {count, plural, one {# Eintrag} other {# Einträge}} aus Ihrer Einkaufsliste entfernt. Dies kann nicht rückgängig gemacht werden.",
+    "sectionTitle": "{name} leeren?",
+    "sectionDescription": "Dadurch werden {count, plural, one {# Eintrag} other {# Einträge}} aus {name} entfernt. Dies kann nicht rückgängig gemacht werden.",
+    "confirm": "Leeren"
   },
   "price": {
     "pending": "Preis wird nachgeschlagen",

--- a/packages/i18n/src/messages/de-informal/groceries.json
+++ b/packages/i18n/src/messages/de-informal/groceries.json
@@ -8,7 +8,8 @@
     "viewMode": "Ansicht",
     "manageStores": "Geschäfte verwalten",
     "storeViewOptions": "Optionen Geschäftsansicht",
-    "groupIngredients": "Zutaten gruppieren"
+    "groupIngredients": "Zutaten gruppieren",
+    "clearList": "Liste leeren"
   },
   "empty": {
     "title": "Deine Einkaufsliste wartet",
@@ -23,8 +24,10 @@
   "store": {
     "unsorted": "Unsortiert",
     "storeActions": "Aktionen",
+    "recipeActions": "Rezeptaktionen",
     "markAllDone": "Alle abhaken",
     "deleteDone": "Erledigte löschen",
+    "clearAll": "Alle löschen",
     "done": "{count} erledigt",
     "allDone": "Alles erledigt",
     "total": "Noch zu kaufen"
@@ -148,6 +151,13 @@
     "invalidPrice": "Gib einen Preis ein, z. B. 2,49",
     "invalidCurrency": "Eine Währung besteht aus drei Buchstaben, z. B. EUR",
     "openPage": "Bei {store} öffnen"
+  },
+  "clearConfirm": {
+    "listTitle": "Liste leeren?",
+    "listDescription": "Dadurch werden {count, plural, one {# Eintrag} other {# Einträge}} aus deiner Einkaufsliste entfernt. Das kann nicht rückgängig gemacht werden.",
+    "sectionTitle": "{name} leeren?",
+    "sectionDescription": "Dadurch werden {count, plural, one {# Eintrag} other {# Einträge}} aus {name} entfernt. Das kann nicht rückgängig gemacht werden.",
+    "confirm": "Leeren"
   },
   "price": {
     "pending": "Preis wird nachgeschlagen",

--- a/packages/i18n/src/messages/en/groceries.json
+++ b/packages/i18n/src/messages/en/groceries.json
@@ -8,7 +8,8 @@
     "viewMode": "View Mode",
     "manageStores": "Manage Stores",
     "storeViewOptions": "Store View Options",
-    "groupIngredients": "Group ingredients"
+    "groupIngredients": "Group ingredients",
+    "clearList": "Clear list"
   },
   "empty": {
     "title": "Your grocery list awaits",
@@ -23,8 +24,10 @@
   "store": {
     "unsorted": "Unsorted",
     "storeActions": "Store actions",
+    "recipeActions": "Recipe actions",
     "markAllDone": "Mark all done",
     "deleteDone": "Delete done",
+    "clearAll": "Clear all",
     "done": "{count} done",
     "allDone": "All done",
     "total": "Still to buy"
@@ -148,6 +151,13 @@
     "invalidPrice": "Enter a price, like 2.49",
     "invalidCurrency": "A currency is three letters, like EUR",
     "openPage": "Open at {store}"
+  },
+  "clearConfirm": {
+    "listTitle": "Clear list?",
+    "listDescription": "This will remove {count, plural, one {# item} other {# items}} from your grocery list. This cannot be undone.",
+    "sectionTitle": "Clear {name}?",
+    "sectionDescription": "This will remove {count, plural, one {# item} other {# items}} from {name}. This cannot be undone.",
+    "confirm": "Clear"
   },
   "price": {
     "pending": "Looking up the price",

--- a/packages/i18n/src/messages/es/groceries.json
+++ b/packages/i18n/src/messages/es/groceries.json
@@ -8,7 +8,8 @@
     "viewMode": "Modo de vista",
     "manageStores": "Gestionar tiendas",
     "storeViewOptions": "Opciones de vista de tienda",
-    "groupIngredients": "Agrupar ingredientes"
+    "groupIngredients": "Agrupar ingredientes",
+    "clearList": "Vaciar lista"
   },
   "empty": {
     "title": "Tu lista de la compra te espera",
@@ -23,8 +24,10 @@
   "store": {
     "unsorted": "Sin asignar",
     "storeActions": "Acciones de la tienda",
+    "recipeActions": "Acciones de la receta",
     "markAllDone": "Marcar todo como comprado",
     "deleteDone": "Eliminar productos comprados",
+    "clearAll": "Vaciar todo",
     "done": "{count} comprados",
     "allDone": "Todo listo",
     "total": "Falta por comprar"
@@ -148,6 +151,13 @@
     "invalidPrice": "Introduce un precio, por ejemplo 2,49",
     "invalidCurrency": "Una moneda tiene tres letras, como EUR",
     "openPage": "Abrir en {store}"
+  },
+  "clearConfirm": {
+    "listTitle": "¿Vaciar la lista?",
+    "listDescription": "Esto eliminará {count, plural, one {# producto} other {# productos}} de tu lista de la compra. Esta acción no se puede deshacer.",
+    "sectionTitle": "¿Vaciar {name}?",
+    "sectionDescription": "Esto eliminará {count, plural, one {# producto} other {# productos}} de {name}. Esta acción no se puede deshacer.",
+    "confirm": "Vaciar"
   },
   "price": {
     "pending": "Buscando el precio",

--- a/packages/i18n/src/messages/fr/groceries.json
+++ b/packages/i18n/src/messages/fr/groceries.json
@@ -8,7 +8,8 @@
     "viewMode": "Mode d'affichage",
     "manageStores": "Gérer les magasins",
     "storeViewOptions": "Options d'affichage par magasin",
-    "groupIngredients": "Grouper les ingrédients"
+    "groupIngredients": "Grouper les ingrédients",
+    "clearList": "Vider la liste"
   },
   "empty": {
     "title": "Votre liste de courses vous attend",
@@ -23,8 +24,10 @@
   "store": {
     "unsorted": "Non trié",
     "storeActions": "Actions du magasin",
+    "recipeActions": "Actions de la recette",
     "markAllDone": "Tout marquer comme fait",
     "deleteDone": "Supprimer les articles faits",
+    "clearAll": "Tout vider",
     "done": "{count} effectués",
     "allDone": "Tout est fait",
     "total": "Reste à acheter"
@@ -148,6 +151,13 @@
     "invalidPrice": "Saisissez un prix, par exemple 2,49",
     "invalidCurrency": "Une devise comporte trois lettres, comme EUR",
     "openPage": "Ouvrir chez {store}"
+  },
+  "clearConfirm": {
+    "listTitle": "Vider la liste ?",
+    "listDescription": "Cela supprimera {count, plural, one {# article} other {# articles}} de votre liste de courses. Cette action est irréversible.",
+    "sectionTitle": "Vider {name} ?",
+    "sectionDescription": "Cela supprimera {count, plural, one {# article} other {# articles}} de {name}. Cette action est irréversible.",
+    "confirm": "Vider"
   },
   "price": {
     "pending": "Recherche du prix",

--- a/packages/i18n/src/messages/it/groceries.json
+++ b/packages/i18n/src/messages/it/groceries.json
@@ -8,7 +8,8 @@
     "viewMode": "Modalità di visualizzazione",
     "manageStores": "Gestisci negozi",
     "storeViewOptions": "Opzioni vista negozio",
-    "groupIngredients": "Raggruppa ingredienti"
+    "groupIngredients": "Raggruppa ingredienti",
+    "clearList": "Svuota lista"
   },
   "empty": {
     "title": "La tua lista della spesa ti aspetta",
@@ -23,8 +24,10 @@
   "store": {
     "unsorted": "Non ordinati",
     "storeActions": "Azioni negozio",
+    "recipeActions": "Azioni ricetta",
     "markAllDone": "Segna tutto come fatto",
     "deleteDone": "Elimina completati",
+    "clearAll": "Svuota tutto",
     "done": "{count} completati",
     "allDone": "Tutto fatto",
     "total": "Ancora da comprare"
@@ -148,6 +151,13 @@
     "invalidPrice": "Inserisci un prezzo, ad esempio 2,49",
     "invalidCurrency": "Una valuta ha tre lettere, come EUR",
     "openPage": "Apri su {store}"
+  },
+  "clearConfirm": {
+    "listTitle": "Svuotare la lista?",
+    "listDescription": "Questo rimuoverà {count, plural, one {# articolo} other {# articoli}} dalla tua lista della spesa. Questa azione non può essere annullata.",
+    "sectionTitle": "Svuotare {name}?",
+    "sectionDescription": "Questo rimuoverà {count, plural, one {# articolo} other {# articoli}} da {name}. Questa azione non può essere annullata.",
+    "confirm": "Svuota"
   },
   "price": {
     "pending": "Ricerca del prezzo in corso",

--- a/packages/i18n/src/messages/ko/groceries.json
+++ b/packages/i18n/src/messages/ko/groceries.json
@@ -8,7 +8,8 @@
     "viewMode": "보기 모드",
     "manageStores": "매장 관리",
     "storeViewOptions": "매장 보기 옵션",
-    "groupIngredients": "재료 묶기"
+    "groupIngredients": "재료 묶기",
+    "clearList": "목록 비우기"
   },
   "empty": {
     "title": "아직 장보기 목록이 비어 있어요",
@@ -23,8 +24,10 @@
   "store": {
     "unsorted": "정렬되지 않음",
     "storeActions": "매장 작업",
+    "recipeActions": "레시피 작업",
     "markAllDone": "모두 완료로 표시",
     "deleteDone": "삭제 완료",
+    "clearAll": "모두 지우기",
     "done": "{count}개 완료",
     "allDone": "모두 완료",
     "total": "아직 살 것"
@@ -148,6 +151,13 @@
     "invalidPrice": "가격을 입력하세요 (예: 2.49)",
     "invalidCurrency": "통화는 세 글자입니다 (예: EUR)",
     "openPage": "{store}에서 열기"
+  },
+  "clearConfirm": {
+    "listTitle": "목록을 비우시겠어요?",
+    "listDescription": "장보기 목록에서 {count}개 항목이 삭제됩니다. 이 작업은 되돌릴 수 없습니다.",
+    "sectionTitle": "{name}을(를) 비우시겠어요?",
+    "sectionDescription": "{name}에서 {count}개 항목이 삭제됩니다. 이 작업은 되돌릴 수 없습니다.",
+    "confirm": "비우기"
   },
   "price": {
     "pending": "가격을 찾는 중",

--- a/packages/i18n/src/messages/nl/groceries.json
+++ b/packages/i18n/src/messages/nl/groceries.json
@@ -8,7 +8,8 @@
     "viewMode": "Weergave",
     "manageStores": "Winkels beheren",
     "storeViewOptions": "Winkelweergave opties",
-    "groupIngredients": "Groepeer ingrediënten"
+    "groupIngredients": "Groepeer ingrediënten",
+    "clearList": "Lijst leegmaken"
   },
   "empty": {
     "title": "Je boodschappenlijst wacht op je",
@@ -23,8 +24,10 @@
   "store": {
     "unsorted": "Ongeordend",
     "storeActions": "Winkelacties",
+    "recipeActions": "Receptacties",
     "markAllDone": "Markeer alles als gekocht",
     "deleteDone": "Verwijder gekocht",
+    "clearAll": "Alles wissen",
     "done": "{count} gedaan",
     "allDone": "Alles gedaan",
     "total": "Nog te kopen"
@@ -148,6 +151,13 @@
     "invalidPrice": "Vul een prijs in, zoals 2,49",
     "invalidCurrency": "Een valuta bestaat uit drie letters, zoals EUR",
     "openPage": "Openen bij {store}"
+  },
+  "clearConfirm": {
+    "listTitle": "Lijst leegmaken?",
+    "listDescription": "Hiermee verwijder je {count, plural, one {# item} other {# items}} uit je boodschappenlijst. Dit kan niet ongedaan worden gemaakt.",
+    "sectionTitle": "{name} leegmaken?",
+    "sectionDescription": "Hiermee verwijder je {count, plural, one {# item} other {# items}} uit {name}. Dit kan niet ongedaan worden gemaakt.",
+    "confirm": "Leegmaken"
   },
   "price": {
     "pending": "Prijs wordt opgezocht",

--- a/packages/i18n/src/messages/no/groceries.json
+++ b/packages/i18n/src/messages/no/groceries.json
@@ -8,7 +8,8 @@
     "viewMode": "Visningsmodus",
     "manageStores": "Administrer butikker",
     "storeViewOptions": "Butikkvisningsinnstillinger",
-    "groupIngredients": "Grupper ingredienser"
+    "groupIngredients": "Grupper ingredienser",
+    "clearList": "Tøm listen"
   },
   "empty": {
     "title": "Handlelisten din venter",
@@ -23,8 +24,10 @@
   "store": {
     "unsorted": "Usortert",
     "storeActions": "Butikkhandlinger",
+    "recipeActions": "Oppskrifthandlinger",
     "markAllDone": "Merk alle som ferdige",
     "deleteDone": "Slett ferdige",
+    "clearAll": "Fjern alle",
     "done": "{count} ferdige",
     "allDone": "Alt ferdig",
     "total": "Igjen å kjøpe"
@@ -148,6 +151,13 @@
     "invalidPrice": "Skriv inn en pris, f.eks. 2,49",
     "invalidCurrency": "En valuta er tre bokstaver, f.eks. EUR",
     "openPage": "Åpne hos {store}"
+  },
+  "clearConfirm": {
+    "listTitle": "Tømme listen?",
+    "listDescription": "Dette fjerner {count, plural, one {# vare} other {# varer}} fra handlelisten din. Dette kan ikke angres.",
+    "sectionTitle": "Tømme {name}?",
+    "sectionDescription": "Dette fjerner {count, plural, one {# vare} other {# varer}} fra {name}. Dette kan ikke angres.",
+    "confirm": "Tøm"
   },
   "price": {
     "pending": "Slår opp prisen",

--- a/packages/i18n/src/messages/pl/groceries.json
+++ b/packages/i18n/src/messages/pl/groceries.json
@@ -8,7 +8,8 @@
     "viewMode": "Widok",
     "manageStores": "Zarządzaj sklepami",
     "storeViewOptions": "Opcje widoku sklepu",
-    "groupIngredients": "Grupuj składniki"
+    "groupIngredients": "Grupuj składniki",
+    "clearList": "Wyczyść listę"
   },
   "empty": {
     "title": "Twoja lista zakupów czeka",
@@ -23,8 +24,10 @@
   "store": {
     "unsorted": "Nieposortowane",
     "storeActions": "Akcje sklepu",
+    "recipeActions": "Akcje przepisu",
     "markAllDone": "Zaznacz wszystkie",
     "deleteDone": "Usuń zaznaczone",
+    "clearAll": "Wyczyść wszystko",
     "done": "{count} gotowe",
     "allDone": "Wszystko gotowe",
     "total": "Jeszcze do kupienia"
@@ -148,6 +151,13 @@
     "invalidPrice": "Wpisz cenę, np. 2,49",
     "invalidCurrency": "Waluta to trzy litery, np. EUR",
     "openPage": "Otwórz w {store}"
+  },
+  "clearConfirm": {
+    "listTitle": "Wyczyścić listę?",
+    "listDescription": "Spowoduje to usunięcie {count, plural, one {# produktu} few {# produktów} many {# produktów} other {# produktu}} z listy zakupów. Tej czynności nie można cofnąć.",
+    "sectionTitle": "Wyczyścić {name}?",
+    "sectionDescription": "Spowoduje to usunięcie {count, plural, one {# produktu} few {# produktów} many {# produktów} other {# produktu}} z {name}. Tej czynności nie można cofnąć.",
+    "confirm": "Wyczyść"
   },
   "price": {
     "pending": "Sprawdzanie ceny",

--- a/packages/i18n/src/messages/pt-BR/groceries.json
+++ b/packages/i18n/src/messages/pt-BR/groceries.json
@@ -8,7 +8,8 @@
     "viewMode": "Modo de visualização",
     "manageStores": "Gerenciar lojas",
     "storeViewOptions": "Opções de visualização por loja",
-    "groupIngredients": "Agrupar ingredientes"
+    "groupIngredients": "Agrupar ingredientes",
+    "clearList": "Limpar lista"
   },
   "empty": {
     "title": "Sua lista de compras espera por você",
@@ -23,8 +24,10 @@
   "store": {
     "unsorted": "Sem classificação",
     "storeActions": "Ações da loja",
+    "recipeActions": "Ações da receita",
     "markAllDone": "Marcar tudo como concluído",
     "deleteDone": "Excluir concluídos",
+    "clearAll": "Limpar tudo",
     "done": "{count} concluído(s)",
     "allDone": "Tudo feito",
     "total": "Ainda por comprar"
@@ -148,6 +151,13 @@
     "invalidPrice": "Informe um preço, como 2,49",
     "invalidCurrency": "Uma moeda tem três letras, como EUR",
     "openPage": "Abrir em {store}"
+  },
+  "clearConfirm": {
+    "listTitle": "Limpar a lista?",
+    "listDescription": "Isso removerá {count, plural, one {# item} other {# itens}} da sua lista de compras. Essa ação não pode ser desfeita.",
+    "sectionTitle": "Limpar {name}?",
+    "sectionDescription": "Isso removerá {count, plural, one {# item} other {# itens}} de {name}. Essa ação não pode ser desfeita.",
+    "confirm": "Limpar"
   },
   "price": {
     "pending": "Procurando o preço",

--- a/packages/i18n/src/messages/ru/groceries.json
+++ b/packages/i18n/src/messages/ru/groceries.json
@@ -8,7 +8,8 @@
     "viewMode": "Режим отображения",
     "manageStores": "Управление магазинами",
     "storeViewOptions": "Настройки отображения магазинов",
-    "groupIngredients": "Группировать ингредиенты"
+    "groupIngredients": "Группировать ингредиенты",
+    "clearList": "Очистить список"
   },
   "empty": {
     "title": "Ваш список покупок ждёт",
@@ -23,8 +24,10 @@
   "store": {
     "unsorted": "Без категории",
     "storeActions": "Действия с магазином",
+    "recipeActions": "Действия с рецептом",
     "markAllDone": "Отметить всё как выполненное",
     "deleteDone": "Удалить выполненные",
+    "clearAll": "Очистить всё",
     "done": "{count, plural, one {# выполнено} few {# выполнено} many {# выполнено} other {# выполнено}}",
     "allDone": "Всё готово",
     "total": "Ещё купить"
@@ -148,6 +151,13 @@
     "invalidPrice": "Введите цену, например 2,49",
     "invalidCurrency": "Валюта состоит из трёх букв, например EUR",
     "openPage": "Открыть в {store}"
+  },
+  "clearConfirm": {
+    "listTitle": "Очистить список?",
+    "listDescription": "Это удалит {count, plural, one {# товар} few {# товара} many {# товаров} other {# товара}} из списка покупок. Это действие нельзя отменить.",
+    "sectionTitle": "Очистить {name}?",
+    "sectionDescription": "Это удалит {count, plural, one {# товар} few {# товара} many {# товаров} other {# товара}} из {name}. Это действие нельзя отменить.",
+    "confirm": "Очистить"
   },
   "price": {
     "pending": "Ищем цену",


### PR DESCRIPTION
## Summary
- Adds three destructive Clear actions, each behind a shared confirm modal: clear the whole grocery list, clear one store/Unsorted section, and clear one recipe/Manual Items group.
- All three resolve the target grocery ids client-side and reuse the existing `deleteGroceries` mutation — no backend changes needed.
- Recipe sections gain a kebab menu for the first time (previously had none), with just "Clear all" since that view has no per-recipe done-tracking concept.
- Added `clearConfirm.*` / `clearList` / `clearAll` / `recipeActions` i18n keys to all 14 locales (`pnpm i18n:check` passes). Non-English translations are mine, not a native speaker's — please have someone sanity-check before merge.

Fixes #558

## Test plan
- [x] `pnpm --filter @norish/web run typecheck`
- [x] `pnpm --filter @norish/web run test` (150 files / 1074 tests)
- [x] `pnpm lint` (0 errors)
- [x] `pnpm format` (prettier clean)
- [x] `pnpm i18n:check` (all locales complete)
- [x] `pnpm --filter @norish/web run build`
- [x] Manually verified against the running dev server: cleared a store, Unsorted, a recipe, and the whole list; confirmed counts/names in the modal and that cleared items stay gone after refresh